### PR TITLE
Added a way of scrolling to the bottom of an element

### DIFF
--- a/src/lib/Browser/Element/BaseElement.php
+++ b/src/lib/Browser/Element/BaseElement.php
@@ -22,7 +22,7 @@ class BaseElement implements BaseElementInterface
     /** @var \Behat\Mink\Element\TraversableElement */
     protected $decoratedElement;
 
-    /** @var \Ibexa\Behat\Browser\Component\ElementFactoryInterface */
+    /** @var \Ibexa\Behat\Browser\Element\Factory\ElementFactoryInterface */
     private $elementFactory;
 
     public function __construct(ElementFactoryInterface $elementFactory)

--- a/src/lib/Browser/Element/Debug/Highlighting/Element.php
+++ b/src/lib/Browser/Element/Debug/Highlighting/Element.php
@@ -100,4 +100,9 @@ final class Element extends BaseElement implements ElementInterface
     {
         return $this->element->getXPath();
     }
+
+    public function scrollToBottom(Session $session): void
+    {
+        $this->element->scrollToBottom($session);
+    }
 }

--- a/src/lib/Browser/Element/Debug/Interactive/Element.php
+++ b/src/lib/Browser/Element/Debug/Interactive/Element.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Behat\Browser\Element\Debug\Interactive;
 
+use Behat\Mink\Session;
 use Exception;
 use Ibexa\Behat\Browser\Assert\Debug\Interactive\ElementAssert as InteractiveElementAssert;
 use Ibexa\Behat\Browser\Assert\ElementAssertInterface;
@@ -105,5 +106,10 @@ final class Element extends BaseElement implements ElementInterface
     public function getXPath(): string
     {
         return $this->element->getXPath();
+    }
+
+    public function scrollToBottom(Session $session): void
+    {
+        $this->element->scrollToBottom($session);
     }
 }

--- a/src/lib/Browser/Element/Element.php
+++ b/src/lib/Browser/Element/Element.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Behat\Browser\Element;
 
 use Behat\Mink\Element\NodeElement;
+use Behat\Mink\Session;
 use Ibexa\Behat\Browser\Assert\ElementAssert;
 use Ibexa\Behat\Browser\Assert\ElementAssertInterface;
 use Ibexa\Behat\Browser\Element\Factory\ElementFactoryInterface;
@@ -125,6 +126,16 @@ final class Element extends BaseElement implements ElementInterface
     public function getXPath(): string
     {
         return $this->decoratedElement->getXpath();
+    }
+
+    public function scrollToBottom(Session $session): void
+    {
+        $script = sprintf(
+            'document.querySelector("%1$s").scrollTo(0, document.querySelector("%1$s").scrollHeight)',
+            $this->locator->getSelector()
+        );
+
+        $session->executeScript($script);
     }
 
     protected function isCheckbox(): bool

--- a/src/lib/Browser/Element/ElementInterface.php
+++ b/src/lib/Browser/Element/ElementInterface.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Behat\Browser\Element;
 
+use Behat\Mink\Session;
 use Ibexa\Behat\Browser\Assert\ElementAssertInterface;
 
 interface ElementInterface extends BaseElementInterface
@@ -43,4 +44,6 @@ interface ElementInterface extends BaseElementInterface
     public function selectOption(string $option): void;
 
     public function getXPath(): string;
+
+    public function scrollToBottom(Session $session): void;
 }


### PR DESCRIPTION
Required by https://github.com/ibexa/workflow/pull/45

Added a way to scroll to the bottom of an Element.

Example usage:
```
$this->getHTMLPage()->find(<CSSLOCATOR>)->scrollToBottom();
```

Mainly used to work around the "go to the top" button that appears out of nowhere and covers the element we want to click on.
