### PR TITLE
Removed generating Content Items with a random date

### DIFF
--- a/src/lib/API/ContentData/ContentDataProvider.php
+++ b/src/lib/API/ContentData/ContentDataProvider.php
@@ -51,7 +51,6 @@ class ContentDataProvider
     {
         $contentType = $this->contentTypeService->loadContentTypeByIdentifier($this->contentTypeIdentifier);
         $contentCreateStruct = $this->contentService->newContentCreateStruct($contentType, $language);
-        $contentCreateStruct->modificationDate = $this->randomDataGenerator->getRandomDateFromThePast();
 
         return $this->fillContentStructWithData($contentType, $language, $language, $contentCreateStruct);
     }


### PR DESCRIPTION
Error in tests:
```
    And there's draft "TestDraftDashboardEdit" on Dashboard list        # Ibexa\AdminUi\Behat\BrowserContext\DashboardContext::goingToDashboardISeeDraft()
      Ibexa\Behat\Browser\Exception\TimeoutException: Next page in pagination was not reloaded in time. Current page is: 5, expected 6 in vendor/ibexa/behat/src/lib/Browser/Element/BaseElement.php:79
      Stack trace:
      #0 vendor/ibexa/admin-ui/src/lib/Behat/Component/Pagination.php(37): Ibexa\Behat\Browser\Element\BaseElement->waitUntil()
      #1 vendor/ibexa/admin-ui/src/lib/Behat/Component/Table/Table.php(76): Ibexa\AdminUi\Behat\Component\Pagination->clickNextButton()
      #2 vendor/ibexa/admin-ui/src/lib/Behat/Page/DashboardPage.php(51): Ibexa\AdminUi\Behat\Component\Table\Table->hasElement()
      #3 vendor/ibexa/admin-ui/src/lib/Behat/BrowserContext/DashboardContext.php(48): Ibexa\AdminUi\Behat\Page\DashboardPage->isDraftOnList()
    │
    │  JS Console errors:
    │  	http://web/favicon.ico - Failed to load resource: the server responded with a status of 404 (Not Found)
    │  Application logs:
    │  	[2022-04-22T10:42:45.987174+00:00] Starting Step "I publish the Landing Page" 
    │  	[2022-04-22T10:42:47.255309+00:00] Ending Step "I publish the Landing Page" 
    │  	[2022-04-22T10:42:47.255666+00:00] Starting Step "success notification that "Content published." appears" 
    │  	[2022-04-22T10:42:49.846460+00:00] Ending Step "success notification that "Content published." appears" 
    │  	[2022-04-22T10:42:49.846876+00:00] Starting Step "I should be on Content view Page for "CreatedLandingPage"" 
    │  	[2022-04-22T10:42:50.551482+00:00] Ending Step "I should be on Content view Page for "CreatedLandingPage"" 
    │  	[2022-04-22T10:42:50.552267+00:00] Ending Scenario "Publishing a Landing Page redirects to that Page" 
    │  	[2022-04-22T10:42:50.642484+00:00] Starting Scenario "Editing existing LP redirects to Page Builder Editor" 
    │  	[2022-04-22T10:42:50.642887+00:00] Starting Step "I am logged as admin" 
    │  	[2022-04-22T10:42:51.723738+00:00] Ending Step "I am logged as admin" 
    │  	[2022-04-22T10:42:51.724061+00:00] Starting Step "I'm on Content view Page for "CreatedLandingPage"" 
    │  	[2022-04-22T10:42:54.555175+00:00] Ending Step "I'm on Content view Page for "CreatedLandingPage"" 
    │  	[2022-04-22T10:42:54.555524+00:00] Starting Step "I click the edit action bar button "Edit"" 
    │  	[2022-04-22T10:42:56.212864+00:00] Ending Step "I click the edit action bar button "Edit"" 
    │  	[2022-04-22T10:42:56.213227+00:00] Starting Step "I should be in Landing Page Edit mode for "CreatedLandingPage" Landing Page" 
    │  	[2022-04-22T10:42:57.723939+00:00] Ending Step "I should be in Landing Page Edit mode for "CreatedLandingPage" Landing Page" 
    │  	[2022-04-22T10:42:57.724286+00:00] Ending Scenario "Editing existing LP redirects to Page Builder Editor" 
    │  	[2022-04-22T10:42:57.788667+00:00] Starting Scenario "Deleting draft of a Landing Page redirects to Content View of the parent" 
    │  	[2022-04-22T10:42:57.788999+00:00] Starting Step "I am logged as admin" 
    │  	[2022-04-22T10:42:58.909769+00:00] Ending Step "I am logged as admin" 
    │  	[2022-04-22T10:42:58.910064+00:00] Starting Step "I'm on Content view Page for "Media"" 
    │  	[2022-04-22T10:43:01.993802+00:00] Ending Step "I'm on Content view Page for "Media"" 
    │  	[2022-04-22T10:43:01.994148+00:00] Starting Step "I start creating a new Landing Page "Delete LandingPage Draft"" 
    │  	[2022-04-22T10:43:04.131627+00:00] Ending Step "there's draft "TestDraftDashboardEdit" on Dashboard list" 
```

![obraz](https://user-images.githubusercontent.com/10993858/165078842-a59d922a-8a27-4ee7-8027-f9c3c230d8f7.png)

This random date from the past work great when generating Content Items for volume benchmarking, but it's not great for Behat tests - the drafts/Content Items are sorted by modification date (descending) on all Dashboard lists and the items we create using the API are usually on the last page because their modification date is a hundred years ago.

This makes the tests slower and also prone to issues related to parallel execution:
In this case you can see that there are 50 drafts, but the tests try to go to the sixth page - when the fifth page was loaded there were 51 Drafts, but then one of them has been removed. It's a similar situation as in https://github.com/ezsystems/ezplatform-admin-ui/pull/1184 , in this case I think the `    │  	[2022-04-22T10:42:45.987174+00:00] Starting Step "I publish the Landing Page" ` Step removed the draft.

I've tested this solution in https://github.com/ibexa/experience/pull/33
