### PR TITLE
[Multirepository] Base new repository config on existing one

### DIFF
--- a/.github/workflows/browser-tests.yaml
+++ b/.github/workflows/browser-tests.yaml
@@ -16,6 +16,7 @@ jobs:
             project-version: '4.1.x-dev'
             test-suite:  '--profile=browser --suite=admin-ui-full'
             test-setup-phase-1: '--profile=regression --suite=setup-oss --mode=standard'
+            multirepository: true
         secrets:
             SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     examples:

--- a/features/setup/multirepository/multirepository.feature
+++ b/features/setup/multirepository/multirepository.feature
@@ -11,16 +11,14 @@ Feature: Multirepository setup for testing
             second_connection:
                 url: '%env(resolve:DATABASE_URL)%'
     """
-    And I set configuration to "ibexa.repositories.new_repository"
+      Given I copy the configuration from "ibexa.repositories.default" to "ibexa.repositories.new_repository"
+      And I append configuration to "ibexa.repositories.new_repository.storage"
         """
-            storage:
-                engine: 'legacy'
                 connection: second_connection
-                config: {}
-            search:
+        """
+      And I append configuration to "ibexa.repositories.new_repository.search"
+        """
                 connection: second_connection
-            product_catalog:
-                engine: default
         """
     And I set configuration to "admin_group" siteaccess
       | key                          | value          |

--- a/src/lib/Core/Configuration/ConfigurationEditor.php
+++ b/src/lib/Core/Configuration/ConfigurationEditor.php
@@ -112,6 +112,18 @@ class ConfigurationEditor implements ConfigurationEditorInterface
 
         return array_merge($currentValue, $value);
     }
+
+    public function copyKey($config, string $keyName, string $newKeyName)
+    {
+        $propertyAccessor = PropertyAccess::createPropertyAccessor();
+
+        $key = $this->parseKey($keyName);
+        $newKey = $this->parseKey($newKeyName);
+        $currentValue = $propertyAccessor->getValue($config, $key);
+        $propertyAccessor->setValue($config, $newKey, $currentValue);
+
+        return $config;
+    }
 }
 
 class_alias(ConfigurationEditor::class, 'EzSystems\Behat\Core\Configuration\ConfigurationEditor');

--- a/src/lib/Core/Configuration/ConfigurationEditorInterface.php
+++ b/src/lib/Core/Configuration/ConfigurationEditorInterface.php
@@ -44,6 +44,8 @@ interface ConfigurationEditorInterface
      * @param $config
      */
     public function saveConfigToFile($filePath, $config): void;
+
+    public function copyKey($config, string $keyName, string $newKeyName);
 }
 
 class_alias(ConfigurationEditorInterface::class, 'EzSystems\Behat\Core\Configuration\ConfigurationEditorInterface');

--- a/src/lib/Core/Configuration/LocationAwareConfigurationEditor.php
+++ b/src/lib/Core/Configuration/LocationAwareConfigurationEditor.php
@@ -75,6 +75,13 @@ class LocationAwareConfigurationEditor implements ConfigurationEditorInterface
             $value = $this->contentFacade->getLocationByLocationURL($matches[1])->id;
         }
     }
+
+    public function copyKey($config, string $keyName, string $newKeyName)
+    {
+        $config = $this->innerConfigurationEditor->copyKey($config, $keyName, $newKeyName);
+
+        return $this->resolveLocationReference($config);
+    }
 }
 
 class_alias(LocationAwareConfigurationEditor::class, 'EzSystems\Behat\Core\Configuration\LocationAwareConfigurationEditor');

--- a/src/lib/Core/Context/ConfigurationContext.php
+++ b/src/lib/Core/Context/ConfigurationContext.php
@@ -22,8 +22,6 @@ class ConfigurationContext implements Context
 
     private $ezplatformConfigFilePath;
 
-    private $configFilePath;
-
     private $projectDir;
 
     /**
@@ -153,6 +151,18 @@ class ConfigurationContext implements Context
         }
 
         return 'append' === $value;
+    }
+
+    /**
+     * @Given I copy the configuration from :keyName to :newKeyName
+     * @Given I copy the configuration from :keyName to :newKeyName in :configFilePath
+     */
+    public function iCopyTheConfigurationFromTo(string $keyName, string $newKeyName, string $configFilePath = null)
+    {
+        $configFilePath = $configFilePath ? sprintf('%s/%s', $this->projectDir, $configFilePath) : $this->ezplatformConfigFilePath;
+        $config = $this->configurationEditor->getConfigFromFile($configFilePath);
+        $config = $this->configurationEditor->copyKey($config, $keyName, $newKeyName);
+        $this->configurationEditor->saveConfigToFile($configFilePath, $config);
     }
 }
 

--- a/tests/lib/Core/Configuration/ConfigurationEditorTest.php
+++ b/tests/lib/Core/Configuration/ConfigurationEditorTest.php
@@ -283,6 +283,16 @@ class ConfigurationEditorTest extends TestCase
 
         Assert::assertEquals(['initialValue1', 'initialValue2'], $value);
     }
+
+    public function testCopiesKey(): void
+    {
+        $configurationEditor = new ConfigurationEditor();
+        $initialConfig = ['baseKey' => ['initialValue1' => 'nestedValue1', 'initialValue2']];
+
+        $changedConfig = $configurationEditor->copyKey($initialConfig, 'baseKey.initialValue1', 'baseKey.copiedKey');
+
+        Assert::assertEquals(['baseKey' => ['initialValue1' => 'nestedValue1', 'initialValue2', 'copiedKey' => 'nestedValue1']], $changedConfig);
+    }
 }
 
 class_alias(ConfigurationEditorTest::class, 'EzSystems\Behat\Test\Core\Configuration\ConfigurationEditorTest');


### PR DESCRIPTION
Follow-up to the changes from https://github.com/ibexa/behat/pull/19/files#diff-0dfc35e37a342600d9ae2f9aafb33a7f5950c30b75d45ecb489512d19910d9edR22-R23

Nightly build error:
https://github.com/ibexa/oss/actions/runs/2471372918
```
 Executing script cache:clear [KO]
 [KO]
Script cache:clear returned with error code 1
!!  
!!  In ArrayNode.php line 322:
!!                                                                                 
!!    Unrecognized option "product_catalog" under "ibexa.repositories.new_reposit  
!!    ory". Available options are "fields_groups", "options", "search", "storage"  
!!    .    
```

My proposed solution is to create the new repository config based on the existing `default` config - and then change what's needed there.

I've tested it locally and the resulting config was (for experience edition):
```yaml
     repositories:
          default:
               storage: null
               search:
                    engine: '%search_engine%'
                    connection: default
               product_catalog:
                    engine: default
          new_repository:
               storage:
                    connection: second_connection
               search:
                    engine: '%search_engine%'
                    connection: second_connection
               product_catalog:
                    engine: default
```

Regression build: https://github.com/ibexa/content/pull/41
AttributeGroups feature has passed:
```
21/32	✔	29 s 330 ms	/var/www/vendor/ibexa/product-catalog/features/AttributeGroups.feature
```