### PR TITLE
[Browser tests] Added 40 min timeout to Admin UI tests

### DIFF
--- a/.github/workflows/browser-tests.yaml
+++ b/.github/workflows/browser-tests.yaml
@@ -17,6 +17,7 @@ jobs:
             test-suite:  '--profile=browser --suite=admin-ui-full'
             test-setup-phase-1: '--profile=regression --suite=setup-oss --mode=standard'
             multirepository: true
+            timeout: 40
         secrets:
             SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     examples:


### PR DESCRIPTION
Change inspired by https://github.com/ibexa/behat/actions/runs/2759256184.

Corresponding setting: https://github.com/ibexa/admin-ui/blob/main/.github/workflows/browser-tests.yaml#L19