### PR TITLE
Adjusted known issues detection to v4

### DIFF
--- a/src/lib/Core/Log/Failure/KnownIssues/ContentTypeCreatedInTheBackground.php
+++ b/src/lib/Core/Log/Failure/KnownIssues/ContentTypeCreatedInTheBackground.php
@@ -15,7 +15,7 @@ class ContentTypeCreatedInTheBackground implements KnownIssueInterface
     public function matches(TestFailureData $testFailureData): bool
     {
         return $testFailureData->applicationLogContainsFragment('DefaultChoiceListFactory') &&
-            $testFailureData->applicationLogContainsFragment('Notice: Undefined index');
+            $testFailureData->applicationLogContainsFragment('Warning: Undefined array key');
     }
 
     public function getJiraReference(): string

--- a/src/lib/Core/Log/Failure/KnownIssues/TextBlockHeaderSelection.php
+++ b/src/lib/Core/Log/Failure/KnownIssues/TextBlockHeaderSelection.php
@@ -14,7 +14,7 @@ class TextBlockHeaderSelection implements KnownIssueInterface
 {
     public function matches(TestFailureData $testFailureData): bool
     {
-        return $testFailureData->exceptionMessageContainsFragment("Could not find element named: 'Paragraph'. Found names")
+        return $testFailureData->exceptionMessageContainsFragment("Could not find element named: 'Paragraph'")
             && $testFailureData->exceptionStackTraceContainsFragment('RichText->changeStyle()');
     }
 


### PR DESCRIPTION
Based on 

1) https://github.com/ibexa/experience/runs/8045075656?check_suite_focus=true
```
     │  	[2022-08-26T22:19:13.337306+00:00] request.CRITICAL: Uncaught PHP Exception Twig\Error\RuntimeError: "An exception has been thrown during the rendering of a template ("Warning: Undefined array key "ezcontentquery"")." at /var/www/vendor/ibexa/admin-ui/src/bundle/Resources/views/themes/admin/content/location_view.html.twig line 31 {"exception":"[object] (Twig\\Error\\RuntimeError(code: 0): An exception has been thrown during the rendering of a template (\"Warning: Undefined array key \"ezcontentquery\"\"). at /var/www/vendor/ibexa/admin-ui/src/bundle/Resources/views/themes/admin/content/location_view.html.twig:31)\n[previous exception] [object] (ErrorException(code: 0): Warning: Undefined array key \"ezcontentquery\" at /var/www/vendor/symfony/form/ChoiceList/Factory/DefaultChoiceListFactory.php:256)"} []
```

2) https://github.com/ibexa/commerce/runs/8045225342?check_suite_focus=true

```
     And I set up block "Text" "Text" with default testing configuration                                                                # Ibexa\PageBuilder\Behat\Context\PageBuilderContext::addBlockWithDefaultTestingConfiguration()
      Ibexa\Behat\Browser\Exception\ElementNotFoundException: Could not find element named: 'Paragraph'. Collection is empty. CSS locator 'toolbarElement': '.ck-button'. in vendor/ibexa/behat/src/lib/Browser/Element/ElementCollection.php:61
```