### PR TITLE
[Composer] Limited doctrine/collections to ^1.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
         "symfony/process": "^5.4",
         "symfony/property-access": "^5.0",
         "symfony/yaml": "^5.0",
-        "psy/psysh": "^0.10.8"
+        "psy/psysh": "^0.10.8",
+        "doctrine/collections": "^1.8"
     },
     "require-dev": {
         "ibexa/code-style": "^1.0",


### PR DESCRIPTION
Right now our tests are failing when using fastest, because it's not compatible with doctrine/collections:^2.0

See: https://github.com/liuggio/fastest/pull/187#issuecomment-1451647396

This is a temporary requirement that will be removed once a release of liuggio/fastest supporting doctrine/collections v2 is available.