### PR TITLE
Selenium upgrade

### DIFF
--- a/behat_ibexa_oss.yaml
+++ b/behat_ibexa_oss.yaml
@@ -34,6 +34,9 @@ default:
                                         - "--no-sandbox"
                                         # problem with different iframe host  - https://bugs.chromium.org/p/chromedriver/issues/detail?id=2758
                                         - "--disable-features=site-per-process"
+                                        - "--disable-renderer-backgrounding"
+                                        - "--disable-background-timer-throttling"
+                                        - "--disable-backgrounding-occluded-window"
                 chrome:
                     chrome:
                         api_url: '%env(string:CHROMIUM_HOST)%'

--- a/behat_ibexa_oss.yaml
+++ b/behat_ibexa_oss.yaml
@@ -23,13 +23,12 @@ default:
             javascript_session: 'selenium'
             sessions:
                 selenium:
-                    selenium2:
+                    webdriver:
                         browser: chrome
                         wd_host: '%env(string:SELENIUM_HOST)%'
                         capabilities:
                             extra_capabilities:
-                                chromeOptions:
-                                    w3c: false
+                                goog:chromeOptions:
                                     args:
                                         - "--window-size=1440,1080"
                                         - "--no-sandbox"
@@ -38,6 +37,8 @@ default:
                 chrome:
                     chrome:
                         api_url: '%env(string:CHROMIUM_HOST)%'
+
+        OAndreyev\MinkPhpWebdriverExtension: ~
 
         DMore\ChromeExtension\Behat\ServiceContainer\ChromeExtension: ~
 

--- a/behat_ibexa_oss.yaml
+++ b/behat_ibexa_oss.yaml
@@ -36,7 +36,7 @@ default:
                                         - "--disable-features=site-per-process"
                                         - "--disable-renderer-backgrounding"
                                         - "--disable-background-timer-throttling"
-                                        - "--disable-backgrounding-occluded-window"
+                                        - "--disable-backgrounding-occluded-windows"
                 chrome:
                     chrome:
                         api_url: '%env(string:CHROMIUM_HOST)%'

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,9 @@
         "symfony/process": "^5.4",
         "symfony/property-access": "^5.0",
         "symfony/yaml": "^5.0",
-        "psy/psysh": "^0.10.8"
+        "psy/psysh": "^0.10.8",
+        "oleg-andreyev/mink-phpwebdriver": "^1.2",
+        "oleg-andreyev/mink-phpwebdriver-extension": "^1.0"
     },
     "require-dev": {
         "ibexa/code-style": "^1.0",

--- a/src/lib/Browser/FileUpload/FileUploadHelper.php
+++ b/src/lib/Browser/FileUpload/FileUploadHelper.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Behat\Browser\FileUpload;
 
+use Behat\Mink\Driver\Selenium2Driver;
 use Behat\Mink\Session;
 use FriendsOfBehat\SymfonyExtension\Mink\MinkParameters;
 
@@ -27,14 +28,19 @@ class FileUploadHelper
 
     public function getRemoteFileUploadPath($filename)
     {
-        if (!preg_match('#[\w\\\/\.]*\.zip$#', $filename)) {
-            throw new \InvalidArgumentException('Zip archive required to upload to remote browser machine.');
+        $localFile = sprintf('%s%s', $this->minkParameters['files_path'], $filename);
+        $driver = $this->session->getDriver();
+
+        if ($driver instanceof Selenium2Driver) {
+            if (!preg_match('#[\w\\\/\.]*\.zip$#', $filename)) {
+                throw new \InvalidArgumentException('Zip archive required to upload to remote browser machine.');
+            }
+
+            return $driver->getWebDriverSession()->file([
+                'file' => base64_encode(file_get_contents($localFile)),
+            ]);
         }
 
-        $localFile = sprintf('%s%s', $this->minkParameters['files_path'], $filename);
-
-        return $this->session->getDriver()->getWebDriverSession()->file([
-            'file' => base64_encode(file_get_contents($localFile)),
-        ]);
+        return $localFile;
     }
 }


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/IBX-4460

All PRs:
https://github.com/ibexa/recipes-dev/pull/60
https://github.com/ibexa/docker/pull/11
https://github.com/ibexa/version-comparison/pull/52
https://github.com/ibexa/admin-ui/pull/726
https://github.com/ibexa/behat/pull/59

Tested in https://github.com/ibexa/commerce/pull/227

### Background

Selenium has stopped publishing new images for the Selenum 3 version:
https://hub.docker.com/r/selenium/standalone-chrome-debug/tags

The latest release is from 2021-09-21, meaning we are using a browser that is slowly becoming outdated - and because new Selenium 3 Docker images are no longer published we need to move away from Selenium 3 and upgrade.

### Solutions considered:
1) Chrome driver for Mink

Repository: https://gitlab.com/behat-chrome/chrome-mink-driver

It promises great results:

> It communicates directly with Google Chrome over HTTP and WebSockets, which allows it to work at least twice as fast as Chrome with Selenium. For Chrome 59+ it supports headless mode, eliminating the need to install a display server,  and the overhead that comes with it. This driver is tested and benchmarked against a behat suite of 1800 scenarios and 19000 steps. It can successfully run it in less than 18 minutes with Chrome 60 headless. The same suite running against Chrome 58 with xvfb and Selenium takes ~60 minutes.


but I was not able to get file uploads to work with this driver - after a file was uploaded the next tests would start failing. 

2) Symfony Panther, together with a Mink extension for it
https://github.com/robertfausk/behat-panther-extension
https://github.com/symfony/panther/

It would be great to use it, because it's closely tied to the Symfony ecosystem - but sadly it cannot be used with remote Selenium out of the box:
https://github.com/symfony/panther/issues/590

Right now the idea is that the driver is installed in the project directory, which doesn't work for us.

3) Selenium2Driver & instaclick/php-webdriver

This is the driver we've used so far, but it's not compatible with Selenium 4.8.0:
https://github.com/instaclick/php-webdriver/issues/122

and when upgrading it would be best to upgrade to the latest version already.
The fact that the issue is one month old already is not a good indicator for the future

3) oleg-andreyev/MinkPhpWebDriver & php-webdriver/php-webdriver

This is the solution that I've chosen

Repositories:
https://github.com/oleg-andreyev/MinkPhpWebDriver
https://github.com/oleg-andreyev/MinkPhpWebdriverExtension

which uses https://github.com/php-webdriver/php-webdriver under the hood

I'm happy that we can switch from https://github.com/instaclick/php-webdriver/ to https://github.com/php-webdriver/php-webdriver, the latter seems more popular which should make the maintenence of test dependencies easier in the future. And it supports Selenium 4.8.0 already 🤩 

## Other changes
1) File uploads don't have to be `zip` anymore (also done in https://github.com/ibexa/admin-ui/pull/726), changed FileUploadHelper to reflect that for the new driver
2) I had a lot of issues when running our tests in parallel - they would randomly fail on CSS transitions.

I was able to find this post:
- https://stackoverflow.com/questions/39765008/selenium-test-hangs-on-css-transition-when-chrome-window-is-sent-to-background-o
- https://support.servicenow.com/kb?id=kb_article_view&sysparm_article=KB0621889

which mentions how to disable background throttling - and with these settings the parallelism issues are gone.