### PR TITLE
[Composer] Removed doctrine/collections dependency

### DIFF
--- a/.github/workflows/browser-tests.yaml
+++ b/.github/workflows/browser-tests.yaml
@@ -17,6 +17,7 @@ jobs:
             test-setup-phase-1: '--profile=regression --suite=setup-oss --mode=standard'
             multirepository: true
             timeout: 40
+            php-image: "ezsystems/php:8.1-v2-node16"
         secrets:
             SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     examples:

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "friends-of-behat/symfony-extension": "^2.1",
         "fakerphp/faker": "^1.17",
         "guzzlehttp/psr7": "^1.6.1",
-        "liuggio/fastest": "^1.7",
+        "liuggio/fastest": "^1.11",
         "php-http/client-common": "^2.1",
         "phpunit/phpunit": "^8.5 || ^9.0 || ^10.0",
         "symfony/config": "^5.0",
@@ -36,8 +36,7 @@
         "symfony/process": "^5.4",
         "symfony/property-access": "^5.0",
         "symfony/yaml": "^5.0",
-        "psy/psysh": "^0.10.8",
-        "doctrine/collections": "^1.8"
+        "psy/psysh": "^0.10.8"
     },
     "require-dev": {
         "ibexa/code-style": "^1.0",


### PR DESCRIPTION
Follow-up to https://github.com/ibexa/behat/pull/58 , which should not be needed after the latest fastest release:
https://github.com/liuggio/fastest/releases/tag/v1.11.0

I've also decided to run one of the test suites on PHP 8.1, so that we cover greater range of available dependencies in PR builds in this repository.