### PR TITLE
IBX-6230: Added validation of CSS selectors

### DIFF
--- a/src/lib/Browser/Locator/CSSLocator.php
+++ b/src/lib/Browser/Locator/CSSLocator.php
@@ -16,7 +16,11 @@ class CSSLocator extends BaseLocator
     {
         parent::__construct($identifier, $selector);
         $validator = new CssLocatorValidator();
-        $validator->validate($this);
+        if (str_contains($selector, '%d') || str_contains($selector, '%s')) {
+            $validator->validate(new self($identifier, str_replace(['%d', '%s'], '1', $selector)));
+        } else {
+            $validator->validate($this);
+        }
     }
 
     public function getType(): string

--- a/src/lib/Browser/Locator/CSSLocator.php
+++ b/src/lib/Browser/Locator/CSSLocator.php
@@ -8,8 +8,17 @@ declare(strict_types=1);
 
 namespace Ibexa\Behat\Browser\Locator;
 
+use Ibexa\Behat\Browser\Locator\Validator\CssLocatorValidator;
+
 class CSSLocator extends BaseLocator
 {
+    public function __construct(string $identifier, string $selector)
+    {
+        parent::__construct($identifier, $selector);
+        $validator = new CssLocatorValidator();
+        $validator->validate($this);
+    }
+
     public function getType(): string
     {
         return 'css';

--- a/src/lib/Browser/Locator/Validator/CssLocatorValidator.php
+++ b/src/lib/Browser/Locator/Validator/CssLocatorValidator.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Behat\Browser\Locator\Validator;
+
+use Ibexa\Behat\Browser\Locator\CSSLocator;
+use Symfony\Component\CssSelector\Exception\ParseException;
+use Symfony\Component\CssSelector\Node\CombinedSelectorNode;
+use Symfony\Component\CssSelector\Node\ElementNode;
+use Symfony\Component\CssSelector\Node\FunctionNode;
+use Symfony\Component\CssSelector\Node\SelectorNode;
+use Symfony\Component\CssSelector\Parser\Parser;
+
+class CssLocatorValidator
+{
+    private Parser $parser;
+
+    private array $partiallySupportedPseudoClasses = ['first-of-type', 'last-of-type', 'nth-of-type', 'nth-last-of-type'];
+
+    public function __construct()
+    {
+        $this->parser = new Parser();
+    }
+
+    public function validate(CSSLocator $cssLocator): void
+    {
+        if (!$this->isValidSelector($cssLocator->getSelector())) {
+            throw new ParseException(
+                sprintf(
+                    "Locator '%s' with ID '%s' cannot be used because of limitations of the CssSelector component. See more: https://symfony.com/doc/current/components/css_selector.html#limitations-of-the-cssselector-component",
+                    $cssLocator->getSelector(),
+                    $cssLocator->getIdentifier()
+                )
+            );
+        }
+    }
+
+    private function isValidSelector(string $selector): bool
+    {
+        $tokens = $this->parser->parse($selector);
+
+        while (!empty($tokens)) {
+            $token = array_pop($tokens);
+
+            if ($token instanceof SelectorNode) {
+                array_push($tokens, $token->getTree());
+            }
+            if ($token instanceof CombinedSelectorNode) {
+                array_push($tokens, $token->getSelector(), $token->getSubSelector());
+            }
+
+            if ($token instanceof FunctionNode) {
+                if (!$this->isValidFunctionNode($token)) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private function isValidFunctionNode(FunctionNode $node): bool
+    {
+        if (!in_array($node->getName(), $this->partiallySupportedPseudoClasses)) {
+            return true;
+        }
+
+        $selector = $node->getSelector();
+
+        if (!($selector instanceof ElementNode)) {
+            $selector = $selector->getSelector();
+        }
+
+        if ($selector->getElement() === null) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/lib/Browser/Locator/Validator/CssLocatorValidator.php
+++ b/src/lib/Browser/Locator/Validator/CssLocatorValidator.php
@@ -13,6 +13,7 @@ use Symfony\Component\CssSelector\Exception\ParseException;
 use Symfony\Component\CssSelector\Node\CombinedSelectorNode;
 use Symfony\Component\CssSelector\Node\ElementNode;
 use Symfony\Component\CssSelector\Node\FunctionNode;
+use Symfony\Component\CssSelector\Node\PseudoNode;
 use Symfony\Component\CssSelector\Node\SelectorNode;
 use Symfony\Component\CssSelector\Parser\Parser;
 
@@ -50,12 +51,19 @@ class CssLocatorValidator
             if ($token instanceof SelectorNode) {
                 array_push($tokens, $token->getTree());
             }
+
             if ($token instanceof CombinedSelectorNode) {
                 array_push($tokens, $token->getSelector(), $token->getSubSelector());
             }
 
             if ($token instanceof FunctionNode) {
                 if (!$this->isValidFunctionNode($token)) {
+                    return false;
+                }
+            }
+
+            if ($token instanceof PseudoNode) {
+                if (!$this->isValidPseudoNode($token)) {
                     return false;
                 }
             }
@@ -67,6 +75,25 @@ class CssLocatorValidator
     private function isValidFunctionNode(FunctionNode $node): bool
     {
         if (!in_array($node->getName(), $this->partiallySupportedPseudoClasses)) {
+            return true;
+        }
+
+        $selector = $node->getSelector();
+
+        if (!($selector instanceof ElementNode)) {
+            $selector = $selector->getSelector();
+        }
+
+        if ($selector->getElement() === null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function isValidPseudoNode(PseudoNode $node): bool
+    {
+        if (!in_array($node->getIdentifier(), $this->partiallySupportedPseudoClasses)) {
             return true;
         }
 

--- a/tests/Browser/Locator/Validator/CssLocatorValidatorTest.php
+++ b/tests/Browser/Locator/Validator/CssLocatorValidatorTest.php
@@ -50,6 +50,7 @@ class CssLocatorValidatorTest extends TestCase
     {
         return [
             ['div'],
+            ['.ibexa-segmentation__items li.ibexa-segmentation__item:last-of-type div.ibexa-segmentation__content-wrapper > button'],
             ['div:nth-of-type(1)'],
             ['div.ibexa-content-field:nth-of-type(3)'],
             ['selector1 section:nth-of-type(2)'],
@@ -67,6 +68,8 @@ class CssLocatorValidatorTest extends TestCase
     {
         return [
             ['.ibexa:nth-of-type(1)'],
+            ['.ibexa-segmentation__items .ibexa-segmentation__item:last-of-type div.ibexa-segmentation__content-wrapper > button'],
+            ['.ibexa-pb-schedule-active-item:nth-of-type(1)'],
             ['.ibexa-table__cell:nth-of-type(5),td:nth-of-type(5)'],
             ['.ibexa-available-field-types__list > li:not(.ibexa-available-field-type--hidden) .ibexa-available-field-type__content:nth-of-type(5)'],
             ['.c-finder-branch:nth-of-type(3) .c-finder-leaf'],

--- a/tests/Browser/Locator/Validator/CssLocatorValidatorTest.php
+++ b/tests/Browser/Locator/Validator/CssLocatorValidatorTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace  Ibexa\Tests\Behat\Browser\Locator\Validator;
+
+use Ibexa\Behat\Browser\Locator\CSSLocator;
+use Ibexa\Behat\Browser\Locator\Validator\CssLocatorValidator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\CssSelector\Exception\ParseException;
+
+class CssLocatorValidatorTest extends TestCase
+{
+    private CssLocatorValidator $validator;
+
+    protected function setUp(): void
+    {
+        $this->validator = new CssLocatorValidator();
+    }
+
+    /**
+     * @dataProvider provideValidSelectors
+     */
+    public function testValidationPasses(string $selector): void
+    {
+        $this->validator->validate(new CSSLocator('test', $selector));
+        $this->expectNotToPerformAssertions();
+    }
+
+    /**
+     * @dataProvider provideInvalidSelectors
+     */
+    public function testValidationFails(string $selector): void
+    {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage(
+            sprintf(
+                "Locator '%s' with ID 'test' cannot be used because of limitations of the CssSelector component. See more: https://symfony.com/doc/current/components/css_selector.html#limitations-of-the-cssselector-component",
+                $selector
+            )
+        );
+        $this->validator->validate(new CSSLocator('test', $selector));
+    }
+
+    public static function provideValidSelectors(): iterable
+    {
+        return [
+            ['div'],
+            ['div:nth-of-type(1)'],
+            ['div.ibexa-content-field:nth-of-type(3)'],
+            ['selector1 section:nth-of-type(2)'],
+            ['tr td:nth-of-type(2)'],
+            ['[data-id="test"] div.ibexa-field-edit:nth-of-type(3)'],
+            ['div.ibexa-details__item:nth-of-type(2) .ibexa-details__item-content'],
+            ['.ibexa-version-compare__field-wrapper div.ibexa-content-field:nth-of-type(1) .ibexa-content-field__name'],
+            ['div.ibexa-dropdown__wrapper > ul.ibexa-dropdown__selection-info > li:nth-child(1)'],
+            ['.ibexa-dropdown__item:nth-child(3)'],
+            ['.nav-item:nth-child(2) .nav-link'],
+        ];
+    }
+
+    public static function provideInvalidSelectors(): iterable
+    {
+        return [
+            ['.ibexa:nth-of-type(1)'],
+            ['.ibexa-table__cell:nth-of-type(5),td:nth-of-type(5)'],
+            ['.ibexa-available-field-types__list > li:not(.ibexa-available-field-type--hidden) .ibexa-available-field-type__content:nth-of-type(5)'],
+            ['.c-finder-branch:nth-of-type(3) .c-finder-leaf'],
+            ['.selector .ibexa:nth-of-type(2)'],
+            ['.tab-pane.active .ibexa-fieldgroup:nth-of-type(2)'],
+            ['div.ibexa-ca-company-tab-company-profile__top-wrapper .ibexa-details__items .ibexa-details__item:nth-of-type(3) .ibexa-details__item-content'],
+        ];
+    }
+}

--- a/tests/lib/Core/Behat/ExtendedTableNodeTest.php
+++ b/tests/lib/Core/Behat/ExtendedTableNodeTest.php
@@ -15,7 +15,6 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
- *
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  *
  * @internal


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/IBX-6230

This PR makes sure that it's not possible to use selectors that are not fully supported by the Symfony CssSelector component.

See: https://symfony.com/doc/current/components/css_selector.html#limitations-of-the-cssselector-component
```
Pseudo-classes are partially supported:

    Not supported: *:first-of-type, *:last-of-type, *:nth-of-type and *:nth-last-of-type (all these work with an element name (e.g. li:first-of-type) but not with the * selector).
```

After this PR is merged it will be impossible to use a selector that is not supported - currently they can be used, but they are incorrectly translated into XPath and result in hard to debug issues.

Error:

<img width="1161" alt="Zrzut ekranu 2023-07-23 o 10 22 47" src="https://github.com/ibexa/behat/assets/10993858/b5691b7b-74e4-40cd-80ab-fe1b85605f02">


Status:
- [ ] Fix incorrect usages in our code first (part 2 of https://issues.ibexa.co/browse/IBX-6230)
- [ ] Merge this PR to protect us in the future