### PR TITLE
Fixed error handling when InteractiveDebug is used outside Component class

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         php:
-          - '8.0'
+          - '8.1'
     steps:
       - uses: actions/checkout@v2
 

--- a/src/lib/Core/Debug/InteractiveDebuggerTrait.php
+++ b/src/lib/Core/Debug/InteractiveDebuggerTrait.php
@@ -83,9 +83,13 @@ trait InteractiveDebuggerTrait
     {
         $trace = debug_backtrace();
         foreach ($trace as $traceLine) {
-            if ($traceLine['function'] === 'eval') {
+            if (!array_key_exists('function', $traceLine) ||
+                    $traceLine['function'] === 'eval' ||
+                    !array_key_exists('object', $traceLine)
+            ) {
                 continue;
             }
+
             $object = $traceLine['object'];
             if ($object instanceof Component) {
                 return $object;


### PR DESCRIPTION
This PR fixes the following error:
```
 When I click edit "TestMyDraft"                                     
 # Ibexa\AdminUi\Behat\BrowserContext\MyDraftsContext::iClickEdit()
      Notice: Undefined index: object in vendor/ibexa/behat/src/lib/Core/Debug/InteractiveDebuggerTrait.php line 89
```

when InteractiveDebug mode is used outside of the Page/Component classes. 