### PR TITLE
Browser log support

### DIFF
--- a/src/lib/Core/Log/TestLogProvider.php
+++ b/src/lib/Core/Log/TestLogProvider.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
 
 namespace Ibexa\Behat\Core\Log;
 
-use Behat\Mink\Driver\Selenium2Driver;
 use Behat\Mink\Session;
+use Facebook\WebDriver\Remote\DriverCommand;
 use Ibexa\Behat\Browser\Filter\BrowserLogFilter;
-use WebDriver\LogType;
+use OAndreyev\Mink\Driver\WebDriver;
 
 final class TestLogProvider
 {
@@ -41,7 +41,7 @@ final class TestLogProvider
     {
         $driver = $this->session->getDriver();
 
-        if (!($driver instanceof Selenium2Driver) || !$this->session->isStarted()) {
+        if (!($driver instanceof WebDriver) || !$this->session->isStarted()) {
             return [];
         }
 
@@ -49,11 +49,15 @@ final class TestLogProvider
             return $this->getCachedLogs();
         }
 
-        $logs = $driver->getWebDriverSession()->log(LogType::BROWSER) ?? [];
-        $parsedLogs = $this->parseBrowserLogs($logs);
+        $parsedLogs = $this->parseBrowserLogs($this->getSeleniumLog($driver));
         $this->cacheLogs($parsedLogs);
 
         return $parsedLogs;
+    }
+
+    private function getSeleniumLog(WebDriver $driver): array
+    {
+        return $driver->getWebDriver()->execute(DriverCommand::GET_LOG, ['type' => 'browser']) ?? [];
     }
 
     public function getApplicationLogs(): array


### PR DESCRIPTION
This PR brings back support for accessing browser logs in PR logs (I had to adapt the solution to Selenium 4).

Tested in:
https://github.com/ibexa/behat/actions/runs/6311453842/job/17135473909?pr=81
```
         │  JS Console errors:
        │  	http://web/favicon.ico - Failed to load resource: the server responded with a status of 404 (Not Found)
```