### PR TITLE
Added locking mechanism to Admin user login

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "symfony/config": "^5.0",
         "symfony/console": "^5.0",
         "symfony/dependency-injection": "^5.0",
+        "symfony/lock": "^5.0",
         "symfony/stopwatch": "^5.2",
         "symfony/http-kernel": "^5.0",
         "symfony/process": "^5.4",

--- a/src/bundle/Resources/views/tests/login_data.html.twig
+++ b/src/bundle/Resources/views/tests/login_data.html.twig
@@ -1,6 +1,6 @@
 <html>
 
-<h1> Current user is: {{ username }}</h1>
+<h1 id="login-success"> Current user is: {{ username }}</h1>
 <h1> Current siteaccess is: {{ siteaccess }}</h1>
 
 </html>

--- a/src/lib/Browser/Page/RedirectLoginPage.php
+++ b/src/lib/Browser/Page/RedirectLoginPage.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Behat\Browser\Page;
 
+use Ibexa\Behat\Browser\Locator\CSSLocator;
 use PHPUnit\Framework\Assert;
 
 class RedirectLoginPage extends LoginPage
@@ -20,6 +21,14 @@ class RedirectLoginPage extends LoginPage
     public function verifyIsLoaded(): void
     {
         Assert::assertStringContainsString('/login', $this->getSession()->getCurrentUrl());
+    }
+
+    public function loginSuccessfully($username, $password): void
+    {
+        parent::loginSuccessfully($username, $password);
+        $this->getHTMLPage()
+            ->findAll(new CSSLocator('loginSuccess', '#login-success'))
+            ->assert()->hasElements();
     }
 
     protected function getRoute(): string


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/IBX-4672

This PR takes advantage of the Lock component (https://symfony.com/doc/current/components/lock.html#flockstore) to make sure only one test  (during parallel execution) is logging in at the same time - this should get rid of this kind of errors we were getting on CI recently.

I've also improved the post-login check, so that we can be sure that the login flow has completed.

Regression PR: https://github.com/ibexa/commerce/pull/394