### PR TITLE
Open the LoginPage only after lock is acquired

### DIFF
--- a/src/lib/Browser/Context/AuthenticationContext.php
+++ b/src/lib/Browser/Context/AuthenticationContext.php
@@ -46,9 +46,9 @@ class AuthenticationContext extends RawMinkContext
         $factory = new LockFactory($store);
 
         $lock = $factory->createLock('admin-login');
-        $this->redirectLoginPage->open('admin');
 
         if ($lock->acquire(true)) {
+            $this->redirectLoginPage->open('admin');
             $this->redirectLoginPage->loginSuccessfully('admin', 'publish');
             $lock->release();
         }


### PR DESCRIPTION
Follow-up to https://github.com/ibexa/behat/pull/82

Example failure:
https://github.com/ibexa/experience/actions/runs/6318654611/job/17158118256

We can see that it failed on parallel login:
```
     │  	[2023-09-26T22:22:02.461565+00:00] Starting Step "I am logged as admin" 
    │  	[2023-09-26T22:22:04.644387+00:00] Ending Step "I am logged as admin" 
    │  	[2023-09-26T22:22:04.644727+00:00] Starting Step "I'm on Content view Page for "TextFieldsContainer/Test URL"" 
    │  	[2023-09-26T22:22:06.034555+00:00] Ending Step "I am logged as admin" 
```

![obraz](https://github.com/ibexa/behat/assets/10993858/4cd9c9f3-ad95-47ba-81c6-e1b873ffb72d)

CSRF token is assigned when the login page is opened - and when other process finishes the login process it is most likely revoked.

Making the page open part of the critical section should solve this issue.

