### PR TITLE
Nested UnauthenticatedLoginRedirect route

### DIFF
--- a/src/bundle/Resources/config/routing.yaml
+++ b/src/bundle/Resources/config/routing.yaml
@@ -9,6 +9,6 @@ ibexa.behat.current_user_data:
         _controller: 'Ibexa\Bundle\Behat\Controller\CurrentUserDataController::showCurrentUserAction'
 
 ibexa_testing_login_redirect:
-    path: '/unauthenticated_login_redirect'
+    path: '/unauthenticated/login_redirect'
     defaults:
         _controller: 'Ibexa\Bundle\Behat\Controller\UnauthenticatedRedirectController::redirectAction'

--- a/src/lib/Browser/Page/RedirectLoginPage.php
+++ b/src/lib/Browser/Page/RedirectLoginPage.php
@@ -33,6 +33,6 @@ class RedirectLoginPage extends LoginPage
 
     protected function getRoute(): string
     {
-        return '/unauthenticated_login_redirect';
+        return '/unauthenticated/login_redirect';
     }
 }


### PR DESCRIPTION
CI failure:
https://github.com/ibexa/experience/actions/runs/6318653184/job/17158104135

For Map\Host the redirect to our custom page is not working - Dashboard is displayed instead.

The responsible code is here:
https://github.com/ibexa/admin-ui/blob/main/src/lib/Security/Authentication/RedirectToDashboardListener.php#L55-L64

I've talked with @ViniTou and we won't be changing this logic for now, so I'm adding a workaround - nesting this path is enough to make it work.

Passing regression build: https://github.com/ibexa/experience/actions/runs/6318653184/job/17158104135