### PR TITLE
Added missing exception to ElementAssert::isVisible

### DIFF
--- a/src/lib/Browser/Element/Element.php
+++ b/src/lib/Browser/Element/Element.php
@@ -10,12 +10,12 @@ namespace Ibexa\Behat\Browser\Element;
 
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Session;
+use Facebook\WebDriver\Exception\NoSuchElementException;
+use Facebook\WebDriver\Exception\StaleElementReferenceException;
 use Ibexa\Behat\Browser\Assert\ElementAssert;
 use Ibexa\Behat\Browser\Assert\ElementAssertInterface;
 use Ibexa\Behat\Browser\Element\Factory\ElementFactoryInterface;
 use Ibexa\Behat\Browser\Locator\LocatorInterface;
-use Webdriver\Exception\NoSuchElement;
-use WebDriver\Exception\StaleElementReference;
 
 final class Element extends BaseElement implements ElementInterface
 {
@@ -33,9 +33,9 @@ final class Element extends BaseElement implements ElementInterface
     {
         try {
             return $this->decoratedElement->isVisible();
-        } catch (StaleElementReference $e) {
+        } catch (NoSuchElementException $element) {
             return false;
-        } catch (NoSuchElement $element) {
+        } catch (StaleElementReferenceException $e) {
             return false;
         }
     }


### PR DESCRIPTION
Examplre failure:
https://github.com/ibexa/admin-ui/actions/runs/6420689702/job/17433347782
```
         Failed step: Then success notification that "Content published." appears
        Facebook\WebDriver\Exception\NoSuchElementException: no such element: Unable to locate element: {"method":"xpath","selector":"(//html/descendant-or-self::*[@class and contains(concat(' ', normalize-space(@class), ' '), ' ibexa-notifications-container ')]/descendant-or-self::*/*[@class and contains(concat(' ', normalize-space(@class), ' '), ' alert ')])[1]"}
```

Exceptions `WebDriver\Exception\StaleElementReference` and `Webdriver\Exception\NoSuchElement` are no longer relevant after upgrade to Selenium4 - they need to be replaced with `Facebook\WebDriver\Exception\NoSuchElementException` and `Facebook\WebDriver\Exception\StaleElementReferenceException`
