### PR TITLE
Introduced RetryChoiceListFactory to deal with parallelism issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
         "symfony/yaml": "^5.0",
         "psy/psysh": "^0.10.8",
         "oleg-andreyev/mink-phpwebdriver": "^1.2",
-        "oleg-andreyev/mink-phpwebdriver-extension": "^1.0"
+        "oleg-andreyev/mink-phpwebdriver-extension": "^1.0",
+        "symfony/form": "^5.4"
     },
     "require-dev": {
         "ibexa/code-style": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,8 @@
         "mikey179/vfsstream": "^1.6",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-phpunit": "^1.3",
-        "phpstan/phpstan-symfony": "^1.3"
+        "phpstan/phpstan-symfony": "^1.3",
+        "symfony/phpunit-bridge": "^6.3"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -136,7 +136,22 @@ parameters:
 			path: src/bundle/Form/RetryChoiceListFactory.php
 
 		-
+			message: "#^Method Ibexa\\\\Bundle\\\\Behat\\\\Form\\\\RetryChoiceListFactory\\:\\:createListFromChoices\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/bundle/Form/RetryChoiceListFactory.php
+
+		-
+			message: "#^Method Ibexa\\\\Bundle\\\\Behat\\\\Form\\\\RetryChoiceListFactory\\:\\:createListFromLoader\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/bundle/Form/RetryChoiceListFactory.php
+
+		-
 			message: "#^Method Ibexa\\\\Bundle\\\\Behat\\\\Form\\\\RetryChoiceListFactory\\:\\:createView\\(\\) has parameter \\$attr with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/bundle/Form/RetryChoiceListFactory.php
+
+		-
+			message: "#^Method Ibexa\\\\Bundle\\\\Behat\\\\Form\\\\RetryChoiceListFactory\\:\\:createView\\(\\) has parameter \\$index with no type specified\\.$#"
 			count: 1
 			path: src/bundle/Form/RetryChoiceListFactory.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -131,6 +131,36 @@ parameters:
 			path: src/bundle/DependencyInjection/IbexaBehatExtension.php
 
 		-
+			message: "#^Method Ibexa\\\\Bundle\\\\Behat\\\\Form\\\\RetryChoiceListFactory\\:\\:createListFromChoices\\(\\) has parameter \\$choices with no value type specified in iterable type iterable\\.$#"
+			count: 1
+			path: src/bundle/Form/RetryChoiceListFactory.php
+
+		-
+			message: "#^Method Ibexa\\\\Bundle\\\\Behat\\\\Form\\\\RetryChoiceListFactory\\:\\:createView\\(\\) has parameter \\$attr with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/bundle/Form/RetryChoiceListFactory.php
+
+		-
+			message: "#^Method Ibexa\\\\Bundle\\\\Behat\\\\Form\\\\RetryChoiceListFactory\\:\\:createView\\(\\) has parameter \\$preferredChoices with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/bundle/Form/RetryChoiceListFactory.php
+
+		-
+			message: "#^Method Symfony\\\\Component\\\\Form\\\\ChoiceList\\\\Factory\\\\ChoiceListFactoryInterface\\:\\:createListFromChoices\\(\\) invoked with 3 parameters, 1\\-2 required\\.$#"
+			count: 1
+			path: src/bundle/Form/RetryChoiceListFactory.php
+
+		-
+			message: "#^Method Symfony\\\\Component\\\\Form\\\\ChoiceList\\\\Factory\\\\ChoiceListFactoryInterface\\:\\:createListFromLoader\\(\\) invoked with 3 parameters, 1\\-2 required\\.$#"
+			count: 1
+			path: src/bundle/Form/RetryChoiceListFactory.php
+
+		-
+			message: "#^Method Symfony\\\\Component\\\\Form\\\\ChoiceList\\\\Factory\\\\ChoiceListFactoryInterface\\:\\:createView\\(\\) invoked with 7 parameters, 1\\-6 required\\.$#"
+			count: 1
+			path: src/bundle/Form/RetryChoiceListFactory.php
+
+		-
 			message: "#^Method Ibexa\\\\Bundle\\\\Behat\\\\IbexaBehatBundle\\:\\:build\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/bundle/IbexaBehatBundle.php
@@ -3024,6 +3054,21 @@ parameters:
 			message: "#^Method Ibexa\\\\Tests\\\\Behat\\\\Browser\\\\Element\\\\Assert\\\\CollectionAssertTest\\:\\:testAssertionPasses\\(\\) has parameter \\$expectedElementTexts with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/Browser/Element/Assert/CollectionAssertTest.php
+
+		-
+			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Behat\\\\Form\\\\Stub\\\\UnstableChoiceListFactory\\:\\:createListFromChoices\\(\\) has parameter \\$choices with no value type specified in iterable type iterable\\.$#"
+			count: 1
+			path: tests/bundle/Form/Stub/UnstableChoiceListFactory.php
+
+		-
+			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Behat\\\\Form\\\\Stub\\\\UnstableChoiceListFactory\\:\\:createView\\(\\) has parameter \\$attr with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/bundle/Form/Stub/UnstableChoiceListFactory.php
+
+		-
+			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Behat\\\\Form\\\\Stub\\\\UnstableChoiceListFactory\\:\\:createView\\(\\) has parameter \\$preferredChoices with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/bundle/Form/Stub/UnstableChoiceListFactory.php
 
 		-
 			message: "#^Method Ibexa\\\\Tests\\\\Behat\\\\Browser\\\\Element\\\\BaseTestCase\\:\\:createCollection\\(\\) has parameter \\$elementTexts with no type specified\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -151,6 +151,11 @@ parameters:
 			path: src/bundle/Form/RetryChoiceListFactory.php
 
 		-
+			message: "#^Method Ibexa\\\\Bundle\\\\Behat\\\\Form\\\\RetryChoiceListFactory\\:\\:createView\\(\\) has parameter \\$groupBy with no type specified\\.$#"
+			count: 1
+			path: src/bundle/Form/RetryChoiceListFactory.php
+
+		-
 			message: "#^Method Ibexa\\\\Bundle\\\\Behat\\\\Form\\\\RetryChoiceListFactory\\:\\:createView\\(\\) has parameter \\$index with no type specified\\.$#"
 			count: 1
 			path: src/bundle/Form/RetryChoiceListFactory.php

--- a/src/bundle/Form/RetryChoiceListFactory.php
+++ b/src/bundle/Form/RetryChoiceListFactory.php
@@ -87,6 +87,7 @@ final class RetryChoiceListFactory implements ChoiceListFactoryInterface
                     throw $e;
                 }
                 ++$counter;
+                usleep(100000 * 2 ** $counter);
             }
         }
     }

--- a/src/bundle/Form/RetryChoiceListFactory.php
+++ b/src/bundle/Form/RetryChoiceListFactory.php
@@ -51,7 +51,7 @@ final class RetryChoiceListFactory implements ChoiceListFactoryInterface
         $preferredChoices = null,
         $label = null,
         $index = null,
-        callable $groupBy = null,
+        $groupBy = null,
         $attr = null
     ): ChoiceListView {
         $labelTranslationParameters = \func_num_args() > 6 ? func_get_arg(6) : [];

--- a/src/bundle/Form/RetryChoiceListFactory.php
+++ b/src/bundle/Form/RetryChoiceListFactory.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\Behat\Form;
+
+use ErrorException;
+use Symfony\Component\Form\ChoiceList\ChoiceListInterface;
+use Symfony\Component\Form\ChoiceList\Factory\ChoiceListFactoryInterface;
+use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
+use Symfony\Component\Form\ChoiceList\View\ChoiceListView;
+
+final class RetryChoiceListFactory implements ChoiceListFactoryInterface
+{
+    private const RETRY_LIMIT = 2;
+
+    private ChoiceListFactoryInterface $choiceListFactory;
+
+    public function __construct(ChoiceListFactoryInterface $choiceListFactory)
+    {
+        $this->choiceListFactory = $choiceListFactory;
+    }
+
+    /** {@inheritDoc} */
+    public function createListFromChoices(iterable $choices, callable $value = null): ChoiceListInterface
+    {
+        $filter = \func_num_args() > 2 ? func_get_arg(2) : null;
+
+        return $this->executeWithRetry(function () use ($choices, $value, $filter) {
+            return $this->choiceListFactory->createListFromChoices($choices, $value, $filter);
+        });
+    }
+
+    /** {@inheritDoc} */
+    public function createListFromLoader(ChoiceLoaderInterface $loader, callable $value = null): ChoiceListInterface
+    {
+        $filter = \func_num_args() > 2 ? func_get_arg(2) : null;
+
+        return $this->executeWithRetry(function () use ($loader, $value, $filter) {
+            return $this->choiceListFactory->createListFromLoader($loader, $value, $filter);
+        });
+    }
+
+    /** {@inheritDoc} */
+    public function createView(
+        ChoiceListInterface $list,
+        $preferredChoices = null,
+        $label = null,
+        callable $index = null,
+        callable $groupBy = null,
+        $attr = null
+    ): ChoiceListView {
+        $labelTranslationParameters = \func_num_args() > 6 ? func_get_arg(6) : [];
+
+        return $this->executeWithRetry(function () use ($list, $preferredChoices, $label, $index, $groupBy, $attr, $labelTranslationParameters) {
+            return $this->choiceListFactory->createView(
+                $list,
+                $preferredChoices,
+                $label,
+                $index,
+                $groupBy,
+                $attr,
+                $labelTranslationParameters
+            );
+        });
+    }
+
+    /**
+     * @template T
+     *
+     * @param callable(mixed ...$args): T $fn
+     *
+     * @return T
+     */
+    private function executeWithRetry(callable $fn)
+    {
+        $counter = 0;
+        while (true) {
+            try {
+                return $fn();
+            } catch (ErrorException $e) {
+                if ($counter > self::RETRY_LIMIT) {
+                    throw $e;
+                }
+                ++$counter;
+            }
+        }
+    }
+}

--- a/src/bundle/Form/RetryChoiceListFactory.php
+++ b/src/bundle/Form/RetryChoiceListFactory.php
@@ -26,7 +26,7 @@ final class RetryChoiceListFactory implements ChoiceListFactoryInterface
     }
 
     /** {@inheritDoc} */
-    public function createListFromChoices(iterable $choices, callable $value = null): ChoiceListInterface
+    public function createListFromChoices(iterable $choices, $value = null): ChoiceListInterface
     {
         $filter = \func_num_args() > 2 ? func_get_arg(2) : null;
 
@@ -36,7 +36,7 @@ final class RetryChoiceListFactory implements ChoiceListFactoryInterface
     }
 
     /** {@inheritDoc} */
-    public function createListFromLoader(ChoiceLoaderInterface $loader, callable $value = null): ChoiceListInterface
+    public function createListFromLoader(ChoiceLoaderInterface $loader, $value = null): ChoiceListInterface
     {
         $filter = \func_num_args() > 2 ? func_get_arg(2) : null;
 
@@ -50,7 +50,7 @@ final class RetryChoiceListFactory implements ChoiceListFactoryInterface
         ChoiceListInterface $list,
         $preferredChoices = null,
         $label = null,
-        callable $index = null,
+        $index = null,
         callable $groupBy = null,
         $attr = null
     ): ChoiceListView {

--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -2,6 +2,7 @@ imports:
     - { resource: services/contexts.yaml }
     - { resource: services/controllers.yaml }
     - { resource: services/factory.yaml }
+    - { resource: services/form.yaml }
     - { resource: services/fieldtype_data_providers.yaml }
     - { resource: services/known_issues.yaml }
     - { resource: services/limitation_parsers.yaml }

--- a/src/bundle/Resources/config/services/form.yaml
+++ b/src/bundle/Resources/config/services/form.yaml
@@ -1,0 +1,8 @@
+services:
+    _defaults:
+      autowire: true
+      autoconfigure: true
+      public: false
+
+    Ibexa\Bundle\Behat\Form\RetryChoiceListFactory:
+      decorates: 'form.choice_list_factory'

--- a/tests/bundle/Form/RetryChoiceListFactoryTest.php
+++ b/tests/bundle/Form/RetryChoiceListFactoryTest.php
@@ -12,11 +12,23 @@ use ErrorException;
 use Ibexa\Bundle\Behat\Form\RetryChoiceListFactory;
 use Ibexa\Tests\Bundle\Behat\Form\Stub\UnstableChoiceListFactory;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ClockMock;
 use Symfony\Component\Form\ChoiceList\ChoiceListInterface;
 use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 
 final class RetryChoiceListFactoryTest extends TestCase
 {
+    public function setUp(): void
+    {
+        ClockMock::register(__CLASS__);
+        ClockMock::withClockMock(true);
+    }
+
+    public function tearDown(): void
+    {
+        ClockMock::withClockMock(false);
+    }
+
     /**
      * @dataProvider provider
      */

--- a/tests/bundle/Form/RetryChoiceListFactoryTest.php
+++ b/tests/bundle/Form/RetryChoiceListFactoryTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\Behat\Form;
+
+use ErrorException;
+use Ibexa\Bundle\Behat\Form\RetryChoiceListFactory;
+use Ibexa\Tests\Bundle\Behat\Form\Stub\UnstableChoiceListFactory;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\ChoiceList\ChoiceListInterface;
+use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
+
+final class RetryChoiceListFactoryTest extends TestCase
+{
+    /**
+     * @dataProvider provider
+     */
+    public function testCreateListFromChoicesSuccess(int $numberOfFails): void
+    {
+        $retryChoiceListFactory = new RetryChoiceListFactory(new UnstableChoiceListFactory($numberOfFails));
+        self::assertEquals([], $retryChoiceListFactory->createListFromChoices([], null)->getChoices());
+    }
+
+    /**
+     * @dataProvider provider
+     */
+    public function testCreateListFromLoaderSuccess(int $numberOfFails): void
+    {
+        $retryChoiceListFactory = new RetryChoiceListFactory(new UnstableChoiceListFactory($numberOfFails));
+        self::assertEquals([], $retryChoiceListFactory->createListFromLoader($this->createMock(ChoiceLoaderInterface::class))->getChoices());
+    }
+
+    /**
+     * @dataProvider provider
+     */
+    public function testCreateViewSuccess(int $numberOfFails): void
+    {
+        $retryChoiceListFactory = new RetryChoiceListFactory(new UnstableChoiceListFactory($numberOfFails));
+        self::assertEquals([], $retryChoiceListFactory->createView($this->createMock(ChoiceListInterface::class), null)->choices);
+    }
+
+    public function testCreateListFromChoicesFail(): void
+    {
+        $retryChoiceListFactory = new RetryChoiceListFactory(new UnstableChoiceListFactory(4));
+        $this->expectException(ErrorException::class);
+        $retryChoiceListFactory->createListFromChoices([], null);
+    }
+
+    public function testCreateListFromLoaderFail(): void
+    {
+        $retryChoiceListFactory = new RetryChoiceListFactory(new UnstableChoiceListFactory(4));
+        $this->expectException(ErrorException::class);
+        $retryChoiceListFactory->createListFromLoader($this->createMock(ChoiceLoaderInterface::class));
+    }
+
+    public function testCreateViewFail(): void
+    {
+        $retryChoiceListFactory = new RetryChoiceListFactory(new UnstableChoiceListFactory(4));
+        $this->expectException(ErrorException::class);
+        $retryChoiceListFactory->createView($this->createMock(ChoiceListInterface::class), null);
+    }
+
+    /**
+     * @return iterable<array<string,int>>
+     */
+    public static function provider(): iterable
+    {
+        yield ['No failures' => 0];
+        yield ['One failure' => 1];
+        yield ['Two failures' => 2];
+        yield ['Three failures' => 3];
+    }
+}

--- a/tests/bundle/Form/Stub/UnstableChoiceListFactory.php
+++ b/tests/bundle/Form/Stub/UnstableChoiceListFactory.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\Behat\Form\Stub;
+
+use ErrorException;
+use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
+use Symfony\Component\Form\ChoiceList\ChoiceListInterface;
+use Symfony\Component\Form\ChoiceList\Factory\ChoiceListFactoryInterface;
+use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
+use Symfony\Component\Form\ChoiceList\View\ChoiceListView;
+
+final class UnstableChoiceListFactory implements ChoiceListFactoryInterface
+{
+    private int $successfulCallAfterNthTry;
+
+    private int $createListFromChoicesCounter = 0;
+
+    private int $createListFromLoaderCounter = 0;
+
+    private int $createViewCounter = 0;
+
+    public function __construct(int $successfulCallAfterNthTry)
+    {
+        $this->successfulCallAfterNthTry = $successfulCallAfterNthTry;
+    }
+
+    public function createListFromChoices(iterable $choices, callable $value = null)
+    {
+        ++$this->createListFromChoicesCounter;
+        $this->failIfNeeded($this->createListFromChoicesCounter);
+
+        return new ArrayChoiceList([]);
+    }
+
+    public function createListFromLoader(ChoiceLoaderInterface $loader, callable $value = null)
+    {
+        ++$this->createListFromLoaderCounter;
+        $this->failIfNeeded($this->createListFromLoaderCounter);
+
+        return new ArrayChoiceList([]);
+    }
+
+    public function createView(ChoiceListInterface $list, $preferredChoices = null, $label = null, callable $index = null, callable $groupBy = null, $attr = null)
+    {
+        ++$this->createViewCounter;
+        $this->failIfNeeded($this->createViewCounter);
+
+        return new ChoiceListView([]);
+    }
+
+    private function failIfNeeded(int $callNumber): void
+    {
+        if ($callNumber <= $this->successfulCallAfterNthTry) {
+            throw new ErrorException(sprintf('Failing call: %d', $callNumber));
+        }
+    }
+}


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/IBX-3075

Regression:
https://github.com/ibexa/experience/pull/253
https://github.com/ibexa/commerce/pull/428

### Issue
1) AdminUI is using a choice loader to load the Content Types ([Type definition](https://github.com/ibexa/admin-ui/blob/main/src/lib/Form/Type/Content/Draft/ContentCreateType.php#L96), [Choice loader](https://github.com/ibexa/admin-ui/blob/main/src/lib/Form/Type/ChoiceList/Loader/ContentCreateContentTypeChoiceLoader.php))
2) Symfony decorates it with [LazyChoiceList](https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/Form/ChoiceList/LazyChoiceList.php):
[It happens here](https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php#L67) and means that the ChoiceLoader needs to load the value every time - LazyChoiceList calls `$this->loader->loadChoiceList` every time under the hood)
3) The list is loaded three times for a single Form:
- [here](https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php#L81)
- [here](https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php#L82)
- [and here](https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php#L148)

Because the list of Content Types is loaded three times for the same Form and we're creating new Content Types in the background there is a possibility that a new Content Type is created between these calls - meaning that different Content Types will be loaded. I believe this causes the error we see on CI - there's a mismatch of loaded Content Types for a single form.

### Solution
`RetryChoiceListFactory` is a simple decorator class that will try to build the form (delegating all the actual building to the original Symfony classes). In case of failure the process will be retried (up to 3 additional times) - if it doesn't succeed 3 times in a row then we will fail as well.

The `func_num_args` function calls need to be stolen directly from Symfony:
[example 1](https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php#L40)
[example 2](https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php#L61)
[example 3](https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php#L77)

Because they have added a new optional parameter in a BC-keeping way (but it's a bit hacky).

### Tests
I've added basic unit tests for this feature - `UnstableChoiceListFactory` is a class that will succeed only after Nth call, making it easy to test this with `RetryChoiceListFactoryTest`.


