### PR TITLE
Add process option

### DIFF
--- a/bin/ibexabehat
+++ b/bin/ibexabehat
@@ -24,6 +24,7 @@ CONFIG=''
 OTHER_OPTIONS=''
 MODE='parallel'
 STRICT='--strict'
+PROCESS=''
 GROUP_COUNT=1
 GROUP_OFFSET=0
 
@@ -40,6 +41,7 @@ Options:
 \t -s, --suite=SUITE; Behat tests suite;
 \t -t, --tags=TAGS; Behat tags filter;
 \t --non-strict; Run Behat in non-strict mode;
+\t -p, --process=M; Number of parallel processes, default: available CPUs;
 \t --group-count; Split the tests into multiple groups
 \t --group-offset; Use together with --group-count, get Scenarios for a group
 " | column -t -s ";"
@@ -57,7 +59,7 @@ behat(){
 }
 
 fastest(){
-    get_behat_features | "$COMPOSER_RUNTIME_BIN_DIR/fastest" --ansi -o -v "$COMPOSER_RUNTIME_BIN_DIR/behat {} ${CONFIG} ${PROFILE}${SUITE}${TAGS}--no-interaction --colors -vv ${STRICT} ${OTHER_OPTIONS}"
+    get_behat_features | "$COMPOSER_RUNTIME_BIN_DIR/fastest" $PROCESS --ansi -o -v "$COMPOSER_RUNTIME_BIN_DIR/behat {} ${CONFIG} ${PROFILE}${SUITE}${TAGS}--no-interaction --colors -vv ${STRICT} ${OTHER_OPTIONS}"
 }
 
 # Fastest option 'list-features' gives us the list of all features from given context in random order, which are later
@@ -81,6 +83,7 @@ case $i in
     -s=*|--suite=*)    SUITE="--suite=${i#*=} ";;
     -t=*|--tags=*)     TAGS="--tags=${i#*=} ";;
     -c=*|--config=*)   CONFIG="--config=${i#*=}";;
+    -p=*|--process=*)  PROCESS="--process=${i#*=}";;
     --non-strict)      STRICT='';;
     --group-count=*)   GROUP_COUNT=${i#*=};;
     --group-offset=*)  GROUP_OFFSET=${i#*=};;


### PR DESCRIPTION
This PR makes it possible to specify the number of processes that will be run in parallel - we need this to limit the number of processes to 1 as a workaround (until we find a fix for the session issue).

Example usage:
```
~/Desktop/Sites/v4 on master !689 ?191 ❯ vendor/bin/ibexabehat --process=1 --profile=browser --suite=admin-ui --tags=@test --dry-run                                    took 9s  14.17.0  3.0.0 at 10:27:24
- 2 test classes into the queue.
- Will be consumed by 1 parallel Processes.
```

```
~/Desktop/Sites/v4 on master !689 ?191 ❯ vendor/bin/ibexabehat --profile=browser --suite=admin-ui --tags=@test --dry-run                                                  ✘ INT  14.17.0  3.0.0 at 10:27:12
- 2 test classes into the queue.
- Will be consumed by 6 parallel Processes.
```

```
~/Desktop/Sites/v4 on master !689 ?191 ❯ vendor/bin/ibexabehat --process=2 --profile=browser --suite=admin-ui --tags=@test                                          took 1m 50s  14.17.0  3.0.0 at 10:05:10
- 2 test classes into the queue.
- Will be consumed by 2 parallel Processes.
```
