### PR TITLE
Added helper find and findAll methods

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1401,11 +1401,6 @@ parameters:
 			path: src/lib/Browser/Element/Action/ChainAction.php
 
 		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\BaseElement\\:\\:findAll\\(\\) return type has no value type specified in iterable type Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollectionInterface\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/BaseElement.php
-
-		-
 			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\BaseElement\\:\\:internalFindAll\\(\\) return type has no value type specified in iterable type Traversable\\.$#"
 			count: 1
 			path: src/lib/Browser/Element/BaseElement.php
@@ -1414,11 +1409,6 @@ parameters:
 			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\BaseElement\\:\\:waitUntil\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/lib/Browser/Element/BaseElement.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\BaseElementInterface\\:\\:findAll\\(\\) return type has no value type specified in iterable type Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollectionInterface\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/BaseElementInterface.php
 
 		-
 			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\BaseElementInterface\\:\\:waitUntil\\(\\) has no return type specified\\.$#"
@@ -1454,11 +1444,6 @@ parameters:
 			message: "#^Property Ibexa\\\\Behat\\\\Browser\\\\Element\\\\Criterion\\\\LogicalOrCriterion\\:\\:\\$results is unused\\.$#"
 			count: 1
 			path: src/lib/Browser/Element/Criterion/LogicalOrCriterion.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\Debug\\\\Highlighting\\\\BaseElement\\:\\:findAll\\(\\) return type has no value type specified in iterable type Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollectionInterface\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/Debug/Highlighting/BaseElement.php
 
 		-
 			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\Debug\\\\Highlighting\\\\BaseElement\\:\\:waitUntil\\(\\) has no return type specified\\.$#"
@@ -1582,11 +1567,6 @@ parameters:
 
 		-
 			message: "#^Invalid type Exception\\|null to throw\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/Debug/Interactive/BaseElement.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\Debug\\\\Interactive\\\\BaseElement\\:\\:findAll\\(\\) return type has no value type specified in iterable type Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollectionInterface\\.$#"
 			count: 1
 			path: src/lib/Browser/Element/Debug/Interactive/BaseElement.php
 
@@ -1991,11 +1971,6 @@ parameters:
 			path: src/lib/Browser/Element/Element.php
 
 		-
-			message: "#^Call to function is_array\\(\\) with iterable\\<Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementInterface\\>&Traversable will always evaluate to false\\.$#"
-			count: 8
-			path: src/lib/Browser/Element/ElementCollection.php
-
-		-
 			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollection\\:\\:__construct\\(\\) has parameter \\$elements with no value type specified in iterable type iterable\\.$#"
 			count: 1
 			path: src/lib/Browser/Element/ElementCollection.php
@@ -2046,26 +2021,6 @@ parameters:
 			path: src/lib/Browser/Element/ElementCollection.php
 
 		-
-			message: "#^PHPDoc tag @return with type array\\<Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementInterface\\> is incompatible with native type Traversable\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/ElementCollection.php
-
-		-
-			message: "#^Property Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollection\\:\\:\\$elements \\(iterable\\<Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementInterface\\>&Traversable\\) does not accept array\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/ElementCollection.php
-
-		-
-			message: "#^Property Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollection\\:\\:\\$elements \\(iterable\\<Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementInterface\\>&Traversable\\) does not accept array\\<Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementInterface\\>\\.$#"
-			count: 7
-			path: src/lib/Browser/Element/ElementCollection.php
-
-		-
-			message: "#^Property Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollection\\:\\:\\$elements \\(iterable\\<Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementInterface\\>&Traversable\\) does not accept iterable\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/ElementCollection.php
-
-		-
 			message: "#^Interface Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollectionInterface extends generic interface IteratorAggregate but does not specify its types\\: TKey, TValue$#"
 			count: 1
 			path: src/lib/Browser/Element/ElementCollectionInterface.php
@@ -2077,11 +2032,6 @@ parameters:
 
 		-
 			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollectionInterface\\:\\:filterBy\\(\\) return type has no value type specified in iterable type Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollectionInterface\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/ElementCollectionInterface.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollectionInterface\\:\\:getIterator\\(\\) return type has no value type specified in iterable type Traversable\\.$#"
 			count: 1
 			path: src/lib/Browser/Element/ElementCollectionInterface.php
 
@@ -2102,11 +2052,6 @@ parameters:
 
 		-
 			message: "#^PHPDoc tag @param has invalid value \\(callable Callable accepting a NodeElement parameter\\)\\: Unexpected token \"Callable\", expected variable at offset 27$#"
-			count: 1
-			path: src/lib/Browser/Element/ElementCollectionInterface.php
-
-		-
-			message: "#^PHPDoc tag @return with type array\\<Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementInterface\\> is incompatible with native type Traversable\\.$#"
 			count: 1
 			path: src/lib/Browser/Element/ElementCollectionInterface.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1116,92 +1116,7 @@ parameters:
 			path: src/lib/API/Facade/UserFacade.php
 
 		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Assert\\\\CollectionAssert\\:\\:__construct\\(\\) has parameter \\$elementCollection with no value type specified in iterable type Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollectionInterface\\.$#"
-			count: 1
-			path: src/lib/Browser/Assert/CollectionAssert.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Assert\\\\CollectionAssert\\:\\:containsElementsWithText\\(\\) has parameter \\$expectedElementTexts with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Browser/Assert/CollectionAssert.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Assert\\\\CollectionAssert\\:\\:containsElementsWithText\\(\\) return type has no value type specified in iterable type Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollectionInterface\\.$#"
-			count: 1
-			path: src/lib/Browser/Assert/CollectionAssert.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Assert\\\\CollectionAssert\\:\\:countEquals\\(\\) return type has no value type specified in iterable type Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollectionInterface\\.$#"
-			count: 1
-			path: src/lib/Browser/Assert/CollectionAssert.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Assert\\\\CollectionAssert\\:\\:hasElements\\(\\) return type has no value type specified in iterable type Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollectionInterface\\.$#"
-			count: 1
-			path: src/lib/Browser/Assert/CollectionAssert.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Assert\\\\CollectionAssert\\:\\:isEmpty\\(\\) return type has no value type specified in iterable type Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollectionInterface\\.$#"
-			count: 1
-			path: src/lib/Browser/Assert/CollectionAssert.php
-
-		-
-			message: "#^Property Ibexa\\\\Behat\\\\Browser\\\\Assert\\\\CollectionAssert\\:\\:\\$elementCollection type has no value type specified in iterable type Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollectionInterface\\.$#"
-			count: 1
-			path: src/lib/Browser/Assert/CollectionAssert.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Assert\\\\CollectionAssertInterface\\:\\:containsElementsWithText\\(\\) has parameter \\$expectedElementTexts with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Browser/Assert/CollectionAssertInterface.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Assert\\\\CollectionAssertInterface\\:\\:containsElementsWithText\\(\\) return type has no value type specified in iterable type Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollectionInterface\\.$#"
-			count: 1
-			path: src/lib/Browser/Assert/CollectionAssertInterface.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Assert\\\\CollectionAssertInterface\\:\\:countEquals\\(\\) return type has no value type specified in iterable type Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollectionInterface\\.$#"
-			count: 1
-			path: src/lib/Browser/Assert/CollectionAssertInterface.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Assert\\\\CollectionAssertInterface\\:\\:hasElements\\(\\) return type has no value type specified in iterable type Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollectionInterface\\.$#"
-			count: 1
-			path: src/lib/Browser/Assert/CollectionAssertInterface.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Assert\\\\CollectionAssertInterface\\:\\:isEmpty\\(\\) return type has no value type specified in iterable type Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollectionInterface\\.$#"
-			count: 1
-			path: src/lib/Browser/Assert/CollectionAssertInterface.php
-
-		-
 			message: "#^Invalid type Exception\\|null to throw\\.$#"
-			count: 1
-			path: src/lib/Browser/Assert/Debug/Interactive/CollectionAssert.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Assert\\\\Debug\\\\Interactive\\\\CollectionAssert\\:\\:containsElementsWithText\\(\\) has parameter \\$expectedElementTexts with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Browser/Assert/Debug/Interactive/CollectionAssert.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Assert\\\\Debug\\\\Interactive\\\\CollectionAssert\\:\\:containsElementsWithText\\(\\) return type has no value type specified in iterable type Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollectionInterface\\.$#"
-			count: 1
-			path: src/lib/Browser/Assert/Debug/Interactive/CollectionAssert.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Assert\\\\Debug\\\\Interactive\\\\CollectionAssert\\:\\:countEquals\\(\\) return type has no value type specified in iterable type Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollectionInterface\\.$#"
-			count: 1
-			path: src/lib/Browser/Assert/Debug/Interactive/CollectionAssert.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Assert\\\\Debug\\\\Interactive\\\\CollectionAssert\\:\\:hasElements\\(\\) return type has no value type specified in iterable type Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollectionInterface\\.$#"
-			count: 1
-			path: src/lib/Browser/Assert/Debug/Interactive/CollectionAssert.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Assert\\\\Debug\\\\Interactive\\\\CollectionAssert\\:\\:isEmpty\\(\\) return type has no value type specified in iterable type Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollectionInterface\\.$#"
 			count: 1
 			path: src/lib/Browser/Assert/Debug/Interactive/CollectionAssert.php
 
@@ -1406,16 +1321,6 @@ parameters:
 			path: src/lib/Browser/Element/BaseElement.php
 
 		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\BaseElement\\:\\:waitUntil\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/BaseElement.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\BaseElementInterface\\:\\:waitUntil\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/BaseElementInterface.php
-
-		-
 			message: "#^Property Ibexa\\\\Behat\\\\Browser\\\\Element\\\\Criterion\\\\ChildElementTextCriterion\\:\\:\\$results type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/Browser/Element/Criterion/ChildElementTextCriterion.php
@@ -1444,11 +1349,6 @@ parameters:
 			message: "#^Property Ibexa\\\\Behat\\\\Browser\\\\Element\\\\Criterion\\\\LogicalOrCriterion\\:\\:\\$results is unused\\.$#"
 			count: 1
 			path: src/lib/Browser/Element/Criterion/LogicalOrCriterion.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\Debug\\\\Highlighting\\\\BaseElement\\:\\:waitUntil\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/Debug/Highlighting/BaseElement.php
 
 		-
 			message: "#^Call to an undefined method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\BaseElementInterface\\:\\:assert\\(\\)\\.$#"
@@ -1587,11 +1487,6 @@ parameters:
 
 		-
 			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\Debug\\\\Interactive\\\\BaseElement\\:\\:startInteractiveSessionOnException\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/Debug/Interactive/BaseElement.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\Debug\\\\Interactive\\\\BaseElement\\:\\:waitUntil\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/lib/Browser/Element/Debug/Interactive/BaseElement.php
 
@@ -1771,41 +1666,6 @@ parameters:
 			path: src/lib/Browser/Element/Debug/Interactive/ElementCollection.php
 
 		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\Debug\\\\Interactive\\\\ElementCollection\\:\\:__construct\\(\\) has parameter \\$baseElementCollection with no value type specified in iterable type Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollectionInterface\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/Debug/Interactive/ElementCollection.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\Debug\\\\Interactive\\\\ElementCollection\\:\\:filter\\(\\) return type has no value type specified in iterable type Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollectionInterface\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/Debug/Interactive/ElementCollection.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\Debug\\\\Interactive\\\\ElementCollection\\:\\:filterBy\\(\\) return type has no value type specified in iterable type Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollectionInterface\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/Debug/Interactive/ElementCollection.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\Debug\\\\Interactive\\\\ElementCollection\\:\\:getIterator\\(\\) return type has no value type specified in iterable type Traversable\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/Debug/Interactive/ElementCollection.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\Debug\\\\Interactive\\\\ElementCollection\\:\\:map\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/Debug/Interactive/ElementCollection.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\Debug\\\\Interactive\\\\ElementCollection\\:\\:mapBy\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/Debug/Interactive/ElementCollection.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\Debug\\\\Interactive\\\\ElementCollection\\:\\:setElements\\(\\) has parameter \\$elements with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/Debug/Interactive/ElementCollection.php
-
-		-
 			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\Debug\\\\Interactive\\\\ElementCollection\\:\\:setInteractiveBreakpoint\\(\\) has parameter \\$variables with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/Browser/Element/Debug/Interactive/ElementCollection.php
@@ -1906,56 +1766,6 @@ parameters:
 			path: src/lib/Browser/Element/Debug/Interactive/RootElement.php
 
 		-
-			message: "#^Call to an undefined method Behat\\\\Mink\\\\Element\\\\TraversableElement\\:\\:attachFile\\(\\)\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/Element.php
-
-		-
-			message: "#^Call to an undefined method Behat\\\\Mink\\\\Element\\\\TraversableElement\\:\\:click\\(\\)\\.$#"
-			count: 2
-			path: src/lib/Browser/Element/Element.php
-
-		-
-			message: "#^Call to an undefined method Behat\\\\Mink\\\\Element\\\\TraversableElement\\:\\:getAttribute\\(\\)\\.$#"
-			count: 3
-			path: src/lib/Browser/Element/Element.php
-
-		-
-			message: "#^Call to an undefined method Behat\\\\Mink\\\\Element\\\\TraversableElement\\:\\:getValue\\(\\)\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/Element.php
-
-		-
-			message: "#^Call to an undefined method Behat\\\\Mink\\\\Element\\\\TraversableElement\\:\\:hasAttribute\\(\\)\\.$#"
-			count: 3
-			path: src/lib/Browser/Element/Element.php
-
-		-
-			message: "#^Call to an undefined method Behat\\\\Mink\\\\Element\\\\TraversableElement\\:\\:hasClass\\(\\)\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/Element.php
-
-		-
-			message: "#^Call to an undefined method Behat\\\\Mink\\\\Element\\\\TraversableElement\\:\\:isVisible\\(\\)\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/Element.php
-
-		-
-			message: "#^Call to an undefined method Behat\\\\Mink\\\\Element\\\\TraversableElement\\:\\:mouseOver\\(\\)\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/Element.php
-
-		-
-			message: "#^Call to an undefined method Behat\\\\Mink\\\\Element\\\\TraversableElement\\:\\:selectOption\\(\\)\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/Element.php
-
-		-
-			message: "#^Call to an undefined method Behat\\\\Mink\\\\Element\\\\TraversableElement\\:\\:setValue\\(\\)\\.$#"
-			count: 3
-			path: src/lib/Browser/Element/Element.php
-
-		-
 			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\Element\\:\\:attachFile\\(\\) has parameter \\$filePath with no type specified\\.$#"
 			count: 1
 			path: src/lib/Browser/Element/Element.php
@@ -1976,77 +1786,7 @@ parameters:
 			path: src/lib/Browser/Element/ElementCollection.php
 
 		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollection\\:\\:filter\\(\\) return type has no value type specified in iterable type Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollectionInterface\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/ElementCollection.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollection\\:\\:filterBy\\(\\) return type has no value type specified in iterable type Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollectionInterface\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/ElementCollection.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollection\\:\\:getIterator\\(\\) return type has no value type specified in iterable type Traversable\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/ElementCollection.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollection\\:\\:internalFilter\\(\\) return type has no value type specified in iterable type iterable\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/ElementCollection.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollection\\:\\:internalFilterBy\\(\\) return type has no value type specified in iterable type iterable\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/ElementCollection.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollection\\:\\:map\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/ElementCollection.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollection\\:\\:mapBy\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/ElementCollection.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollection\\:\\:setElements\\(\\) has parameter \\$elements with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/ElementCollection.php
-
-		-
-			message: "#^PHPDoc tag @param has invalid value \\(callable Callable accepting a NodeElement parameter\\)\\: Unexpected token \"Callable\", expected variable at offset 27$#"
-			count: 1
-			path: src/lib/Browser/Element/ElementCollection.php
-
-		-
 			message: "#^Interface Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollectionInterface extends generic interface IteratorAggregate but does not specify its types\\: TKey, TValue$#"
-			count: 1
-			path: src/lib/Browser/Element/ElementCollectionInterface.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollectionInterface\\:\\:filter\\(\\) return type has no value type specified in iterable type Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollectionInterface\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/ElementCollectionInterface.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollectionInterface\\:\\:filterBy\\(\\) return type has no value type specified in iterable type Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollectionInterface\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/ElementCollectionInterface.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollectionInterface\\:\\:map\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/ElementCollectionInterface.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollectionInterface\\:\\:mapBy\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/ElementCollectionInterface.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollectionInterface\\:\\:setElements\\(\\) has parameter \\$elements with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/Browser/Element/ElementCollectionInterface.php
 
@@ -2069,21 +1809,6 @@ parameters:
 			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementInterface\\:\\:setValue\\(\\) has parameter \\$value with no type specified\\.$#"
 			count: 1
 			path: src/lib/Browser/Element/ElementInterface.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Element\\\\Mapper\\\\MapperInterface\\:\\:map\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/Mapper/MapperInterface.php
-
-		-
-			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/RootElement.php
-
-		-
-			message: "#^Property Ibexa\\\\Behat\\\\Browser\\\\Element\\\\RootElement\\:\\:\\$session has no type specified\\.$#"
-			count: 1
-			path: src/lib/Browser/Element/RootElement.php
 
 		-
 			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Environment\\\\ParameterProvider\\:\\:setParameter\\(\\) has parameter \\$value with no type specified\\.$#"
@@ -2134,16 +1859,6 @@ parameters:
 			message: "#^Property Ibexa\\\\Behat\\\\Browser\\\\Filter\\\\BrowserLogFilter\\:\\:\\$excludedPatterns has no type specified\\.$#"
 			count: 1
 			path: src/lib/Browser/Filter/BrowserLogFilter.php
-
-		-
-			message: "#^Property Ibexa\\\\Behat\\\\Browser\\\\Locator\\\\BaseLocator\\:\\:\\$identifier has no type specified\\.$#"
-			count: 1
-			path: src/lib/Browser/Locator/BaseLocator.php
-
-		-
-			message: "#^Property Ibexa\\\\Behat\\\\Browser\\\\Locator\\\\BaseLocator\\:\\:\\$selector has no type specified\\.$#"
-			count: 1
-			path: src/lib/Browser/Locator/BaseLocator.php
 
 		-
 			message: "#^Method Ibexa\\\\Behat\\\\Browser\\\\Locator\\\\CSSLocatorBuilder\\:\\:combine\\(\\) has parameter \\$locators with no type specified\\.$#"
@@ -2981,11 +2696,6 @@ parameters:
 			path: tests/Browser/Element/Assert/CollectionAssertTest.php
 
 		-
-			message: "#^Method Ibexa\\\\Tests\\\\Behat\\\\Browser\\\\Element\\\\Assert\\\\CollectionAssertTest\\:\\:createElementCollection\\(\\) return type has no value type specified in iterable type Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollection\\.$#"
-			count: 1
-			path: tests/Browser/Element/Assert/CollectionAssertTest.php
-
-		-
 			message: "#^Method Ibexa\\\\Tests\\\\Behat\\\\Browser\\\\Element\\\\Assert\\\\CollectionAssertTest\\:\\:provideForTestAssertionFails\\(\\) return type has no value type specified in iterable type iterable\\.$#"
 			count: 1
 			path: tests/Browser/Element/Assert/CollectionAssertTest.php
@@ -3032,11 +2742,6 @@ parameters:
 
 		-
 			message: "#^Method Ibexa\\\\Tests\\\\Behat\\\\Browser\\\\Element\\\\BaseTestCase\\:\\:createCollection\\(\\) has parameter \\$elementTexts with no type specified\\.$#"
-			count: 1
-			path: tests/lib/Browser/Element/BaseTestCase.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Behat\\\\Browser\\\\Element\\\\BaseTestCase\\:\\:createCollection\\(\\) return type has no value type specified in iterable type Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollection\\.$#"
 			count: 1
 			path: tests/lib/Browser/Element/BaseTestCase.php
 
@@ -3112,11 +2817,6 @@ parameters:
 
 		-
 			message: "#^Method Ibexa\\\\Tests\\\\Behat\\\\Browser\\\\Element\\\\ElementCollectionTest\\:\\:testEmpty\\(\\) has parameter \\$elementNames with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/lib/Browser/Element/ElementCollectionTest.php
-
-		-
-			message: "#^Property Ibexa\\\\Tests\\\\Behat\\\\Browser\\\\Element\\\\ElementCollectionTest\\:\\:\\$collection type has no value type specified in iterable type Ibexa\\\\Behat\\\\Browser\\\\Element\\\\ElementCollection\\.$#"
 			count: 1
 			path: tests/lib/Browser/Element/ElementCollectionTest.php
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,6 +4,7 @@ includes:
     - vendor/phpstan/phpstan-symfony/extension.neon
 
 parameters:
+    treatPhpDocTypesAsCertain: false
     level: 8
     paths:
         - src

--- a/src/lib/Browser/Assert/CollectionAssertInterface.php
+++ b/src/lib/Browser/Assert/CollectionAssertInterface.php
@@ -18,5 +18,6 @@ interface CollectionAssertInterface
 
     public function countEquals(int $expectedCount): ElementCollectionInterface;
 
+    /** @param array<string> $expectedElementTexts */
     public function containsElementsWithText(array $expectedElementTexts): ElementCollectionInterface;
 }

--- a/src/lib/Browser/Component/Component.php
+++ b/src/lib/Browser/Component/Component.php
@@ -53,7 +53,6 @@ abstract class Component implements ComponentInterface
         return $this->getHTMLPage()->find($locator);
     }
 
-    /** @return ElementCollectionInterface<ElementInterface> */
     public function findAll(LocatorInterface $locator): ElementCollectionInterface
     {
         return $this->getHTMLPage()->findAll($locator);

--- a/src/lib/Browser/Component/Component.php
+++ b/src/lib/Browser/Component/Component.php
@@ -10,6 +10,8 @@ namespace Ibexa\Behat\Browser\Component;
 
 use Behat\Mink\Session;
 use Facebook\WebDriver\Chrome\ChromeDevToolsDriver;
+use Ibexa\Behat\Browser\Element\ElementCollectionInterface;
+use Ibexa\Behat\Browser\Element\ElementInterface;
 use Ibexa\Behat\Browser\Element\Factory\Debug\Highlighting\ElementFactory as HighlightingDebugElementFactory;
 use Ibexa\Behat\Browser\Element\Factory\Debug\Interactive\ElementFactory as InteractiveDebugElementFactory;
 use Ibexa\Behat\Browser\Element\Factory\ElementFactory;
@@ -44,6 +46,17 @@ abstract class Component implements ComponentInterface
     final protected function getHTMLPage(): RootElementInterface
     {
         return $this->elementFactory->createRootElement($this->getSession(), $this->elementFactory);
+    }
+
+    public function find(LocatorInterface $locator): ElementInterface
+    {
+        return $this->getHTMLPage()->find($locator);
+    }
+
+    /** @return ElementCollectionInterface<ElementInterface> */
+    public function findAll(LocatorInterface $locator): ElementCollectionInterface
+    {
+        return $this->getHTMLPage()->findAll($locator);
     }
 
     public function setElementFactory(ElementFactoryInterface $elementFactory): void

--- a/src/lib/Browser/Element/BaseElement.php
+++ b/src/lib/Browser/Element/BaseElement.php
@@ -8,22 +8,18 @@ declare(strict_types=1);
 
 namespace Ibexa\Behat\Browser\Element;
 
+use Behat\Mink\Element\ElementInterface as MinkElementInterface;
 use Ibexa\Behat\Browser\Element\Condition\ConditionInterface;
 use Ibexa\Behat\Browser\Element\Factory\ElementFactoryInterface;
 use Ibexa\Behat\Browser\Exception\TimeoutException;
 use Ibexa\Behat\Browser\Locator\LocatorInterface;
 use Traversable;
 
-class BaseElement implements BaseElementInterface
+abstract class BaseElement implements BaseElementInterface
 {
-    /** @var int */
-    protected $timeout = 1;
+    protected int $timeout = 1;
 
-    /** @var \Behat\Mink\Element\TraversableElement */
-    protected $decoratedElement;
-
-    /** @var \Ibexa\Behat\Browser\Element\Factory\ElementFactoryInterface */
-    private $elementFactory;
+    private ElementFactoryInterface $elementFactory;
 
     public function __construct(ElementFactoryInterface $elementFactory)
     {
@@ -83,7 +79,7 @@ class BaseElement implements BaseElementInterface
     {
         return $this->waitUntil(
             function () use ($locator) {
-                $foundMinkElements = $this->decoratedElement->findAll($locator->getType(), $locator->getSelector());
+                $foundMinkElements = $this->getDecoratedElement()->findAll($locator->getType(), $locator->getSelector());
 
                 foreach ($foundMinkElements as $foundMinkElement) {
                     $wrappedElement = $this->elementFactory->createElement($this->elementFactory, $locator, $foundMinkElement);
@@ -116,7 +112,7 @@ class BaseElement implements BaseElementInterface
     {
         try {
             $minkElements = $this->waitUntil(function () use ($locator) {
-                $minkElements = $this->decoratedElement->findAll($locator->getType(), $locator->getSelector());
+                $minkElements = $this->getDecoratedElement()->findAll($locator->getType(), $locator->getSelector());
                 foreach ($minkElements as $minkElement) {
                     if (!$minkElement->isValid()) {
                         return false;
@@ -138,4 +134,6 @@ class BaseElement implements BaseElementInterface
             }
         }
     }
+
+    abstract protected function getDecoratedElement(): MinkElementInterface;
 }

--- a/src/lib/Browser/Element/BaseElementInterface.php
+++ b/src/lib/Browser/Element/BaseElementInterface.php
@@ -19,6 +19,7 @@ interface BaseElementInterface
 
     public function find(LocatorInterface $locator): ElementInterface;
 
+    /** @return ElementCollectionInterface<ElementInterface> */
     public function findAll(LocatorInterface $locator): ElementCollectionInterface;
 
     public function waitUntilCondition(ConditionInterface $condition): BaseElementInterface;

--- a/src/lib/Browser/Element/BaseElementInterface.php
+++ b/src/lib/Browser/Element/BaseElementInterface.php
@@ -19,10 +19,14 @@ interface BaseElementInterface
 
     public function find(LocatorInterface $locator): ElementInterface;
 
-    /** @return ElementCollectionInterface<ElementInterface> */
     public function findAll(LocatorInterface $locator): ElementCollectionInterface;
 
     public function waitUntilCondition(ConditionInterface $condition): BaseElementInterface;
 
+    /**
+     * @param callable(mixed): mixed $callback
+     *
+     * @return mixed
+     */
     public function waitUntil(callable $callback, string $errorMessage);
 }

--- a/src/lib/Browser/Element/Element.php
+++ b/src/lib/Browser/Element/Element.php
@@ -20,8 +20,9 @@ use Ibexa\Behat\Browser\Locator\LocatorInterface;
 
 final class Element extends BaseElement implements ElementInterface
 {
-    /** @var \Ibexa\Behat\Browser\Locator\LocatorInterface */
-    private $locator;
+    private LocatorInterface $locator;
+
+    private NodeElement $decoratedElement;
 
     public function __construct(ElementFactoryInterface $elementFactory, LocatorInterface $locator, NodeElement $baseElement)
     {
@@ -116,7 +117,7 @@ final class Element extends BaseElement implements ElementInterface
 
     public function isValid(): bool
     {
-        return null !== $this->decoratedElement ? $this->decoratedElement->isValid() : false;
+        return $this->decoratedElement->isValid();
     }
 
     public function selectOption(string $option): void
@@ -152,5 +153,10 @@ final class Element extends BaseElement implements ElementInterface
     public function execute(ActionInterface $action): void
     {
         $action->execute($this);
+    }
+
+    protected function getDecoratedElement(): NodeElement
+    {
+        return $this->decoratedElement;
     }
 }

--- a/src/lib/Browser/Element/ElementCollection.php
+++ b/src/lib/Browser/Element/ElementCollection.php
@@ -22,10 +22,7 @@ class ElementCollection implements ElementCollectionInterface
     /** @var iterable<ElementInterface> */
     private $elements;
 
-    /**
-     * @var \Ibexa\Behat\Browser\Locator\LocatorInterface
-     */
-    private $locator;
+    private LocatorInterface $locator;
 
     public function __construct(LocatorInterface $locator, iterable $elements)
     {
@@ -44,7 +41,7 @@ class ElementCollection implements ElementCollectionInterface
             return new \ArrayIterator($this->elements);
         }
 
-        yield from $this->elements;
+        return $this->elements;
     }
 
     public function getByCriterion(CriterionInterface $criterion): ElementInterface
@@ -61,7 +58,7 @@ class ElementCollection implements ElementCollectionInterface
     }
 
     /**
-     * @param callable Callable accepting a NodeElement parameter
+     * @param callable(ElementInterface): bool $callable
      */
     public function getBy(callable $callable): ElementInterface
     {
@@ -205,6 +202,11 @@ class ElementCollection implements ElementCollectionInterface
         return new CollectionAssert($this->locator, $this);
     }
 
+    /**
+     * @param callable(ElementInterface $element): bool $callable
+     *
+     * @return iterable<ElementInterface>
+     */
     private function internalFilter(callable $callable): iterable
     {
         foreach ($this->elements as $element) {
@@ -214,6 +216,7 @@ class ElementCollection implements ElementCollectionInterface
         }
     }
 
+    /** @return iterable<ElementInterface> */
     private function internalFilterBy(CriterionInterface $criterion): iterable
     {
         foreach ($this->elements as $element) {

--- a/src/lib/Browser/Element/ElementCollection.php
+++ b/src/lib/Browser/Element/ElementCollection.php
@@ -19,7 +19,7 @@ use Traversable;
 
 class ElementCollection implements ElementCollectionInterface
 {
-    /** @var ElementInterface[]|\Traversable */
+    /** @var iterable<ElementInterface> */
     private $elements;
 
     /**
@@ -38,16 +38,13 @@ class ElementCollection implements ElementCollectionInterface
         $this->elements = $elements;
     }
 
-    /**
-     * @return \Ibexa\Behat\Browser\Element\ElementInterface[]
-     */
     public function getIterator(): Traversable
     {
         if (is_array($this->elements)) {
             return new \ArrayIterator($this->elements);
         }
 
-        return $this->elements;
+        yield from $this->elements;
     }
 
     public function getByCriterion(CriterionInterface $criterion): ElementInterface

--- a/src/lib/Browser/Element/ElementCollectionInterface.php
+++ b/src/lib/Browser/Element/ElementCollectionInterface.php
@@ -16,12 +16,12 @@ use Traversable;
 interface ElementCollectionInterface extends \Countable, \IteratorAggregate
 {
     /**
-     * @return ElementCollectionInterface<ElementInterface>
+     * @return Traversable<ElementInterface>
      */
     public function getIterator(): Traversable;
 
     /**
-     * @parameter array<ElementInterface> $elements;
+     * @param array<ElementInterface> $elements
      */
     public function setElements(array $elements): void;
 
@@ -47,10 +47,19 @@ interface ElementCollectionInterface extends \Countable, \IteratorAggregate
 
     public function single(): ElementInterface;
 
+    /**
+     * @param callable(ElementInterface): mixed $callable
+     *
+     * @return array<mixed>
+     */
     public function map(callable $callable): array;
 
+    /** @return array<mixed> */
     public function mapBy(MapperInterface $mapper): array;
 
+    /**
+     * @param callable(ElementInterface): bool $callable
+     */
     public function filter(callable $callable): ElementCollectionInterface;
 
     public function filterBy(CriterionInterface $criterion): ElementCollectionInterface;

--- a/src/lib/Browser/Element/ElementCollectionInterface.php
+++ b/src/lib/Browser/Element/ElementCollectionInterface.php
@@ -16,10 +16,13 @@ use Traversable;
 interface ElementCollectionInterface extends \Countable, \IteratorAggregate
 {
     /**
-     * @return \Ibexa\Behat\Browser\Element\ElementInterface[]
+     * @return ElementCollectionInterface<ElementInterface>
      */
     public function getIterator(): Traversable;
 
+    /**
+     * @parameter array<ElementInterface> $elements;
+     */
     public function setElements(array $elements): void;
 
     public function getByCriterion(CriterionInterface $criterion): ElementInterface;

--- a/src/lib/Browser/Element/Mapper/MapperInterface.php
+++ b/src/lib/Browser/Element/Mapper/MapperInterface.php
@@ -12,5 +12,6 @@ use Ibexa\Behat\Browser\Element\ElementInterface;
 
 interface MapperInterface
 {
+    /** @return mixed */
     public function map(ElementInterface $element);
 }

--- a/src/lib/Browser/Element/RootElement.php
+++ b/src/lib/Browser/Element/RootElement.php
@@ -15,8 +15,9 @@ use RuntimeException;
 
 final class RootElement extends BaseElement implements RootElementInterface
 {
-    /** @vat \Behat\Mink\Session */
-    private $session;
+    private Session $session;
+
+    private DocumentElement $decoratedElement;
 
     public function __construct(ElementFactoryInterface $elementFactory, Session $session, DocumentElement $baseElement)
     {
@@ -42,6 +43,11 @@ final class RootElement extends BaseElement implements RootElementInterface
 
     public function executeJavaScript(string $script): string
     {
-        return (string) $this->session->evaluateScript($script) ?? '';
+        return $this->session->evaluateScript($script) ?? '';
+    }
+
+    protected function getDecoratedElement(): DocumentElement
+    {
+        return $this->decoratedElement;
     }
 }

--- a/src/lib/Browser/Locator/BaseLocator.php
+++ b/src/lib/Browser/Locator/BaseLocator.php
@@ -12,9 +12,9 @@ use Ibexa\Behat\Browser\Element\ElementInterface;
 
 abstract class BaseLocator implements LocatorInterface
 {
-    protected $selector;
+    protected string $selector;
 
-    protected $identifier;
+    protected string $identifier;
 
     public function __construct(string $identifier, string $selector)
     {

--- a/src/lib/Browser/Page/LoginPage.php
+++ b/src/lib/Browser/Page/LoginPage.php
@@ -24,9 +24,9 @@ class LoginPage extends Page
 
     public function loginSuccessfully($username, $password): void
     {
-        $this->getHTMLPage()->find($this->getLocator('username'))->setValue($username);
-        $this->getHTMLPage()->find($this->getLocator('password'))->setValue($password);
-        $this->getHTMLPage()->findAll($this->getLocator('button'))
+        $this->find($this->getLocator('username'))->setValue($username);
+        $this->find($this->getLocator('password'))->setValue($password);
+        $this->findAll($this->getLocator('button'))
             ->filterBy(new LogicalOrCriterion([
                 new ElementTextCriterion('Login'),
                 new ElementTextCriterion('Log in'),

--- a/src/lib/Browser/Page/Preview/FolderPreview.php
+++ b/src/lib/Browser/Page/Preview/FolderPreview.php
@@ -23,7 +23,7 @@ class FolderPreview extends Component implements PagePreviewInterface
 
     public function verifyPreviewData()
     {
-        $this->getHTMLPage()->find($this->getLocator('title'))->assert()->textEquals($this->expectedPageTitle);
+        $this->find($this->getLocator('title'))->assert()->textEquals($this->expectedPageTitle);
     }
 
     public function supports(string $contentTypeIdentifier, string $viewType): bool


### PR DESCRIPTION
This PR makes it possible to invoke the `find` and `findAll` methods directly in Pages and Components - without calling `getHTMLPage` first.

It's a small thing, but should make our tests more readable and quicker to write.

I've also did small refactoring with PHPStan (I didn't want to introduce new issues into the baseline).

Regression: https://github.com/ibexa/commerce/pull/530