### PR TITLE
[Behat] Restricted content/read policy for the AddLocation user

### DIFF
--- a/features/personas/add_location.feature
+++ b/features/personas/add_location.feature
@@ -8,9 +8,11 @@ Feature: Editor user that has policies with Content Type limitation
     And I create a user group "AddLocationGroup"
     And I create a user "Add" with last name "Location" in group "AddLocationGroup"
     And I create a role "AddLocationRole" with policies
-      | module | function |
-      | user   | login    |
-      | content | read    |
+      | module  | function |
+      | user    | login    |
+    And I add policy "content" "read" to "AddLocationRole" with limitations
+        | limitationType | limitationValue             |
+        | Content Type   | article,folder,landing_page |
     And I add policy "content" "create" to "AddLocationRole" with limitations
       | limitationType | limitationValue |
       | ContentType    | Article         |

--- a/features/personas/add_location.feature
+++ b/features/personas/add_location.feature
@@ -11,8 +11,11 @@ Feature: Editor user that has policies with Content Type limitation
       | module  | function |
       | user    | login    |
     And I add policy "content" "read" to "AddLocationRole" with limitations
-        | limitationType | limitationValue             |
-        | Content Type   | article,folder,landing_page |
+      | limitationType | limitationValue |
+      | Content Type   | article,folder  |
+    And I add policy "content" "read" to "AddLocationRole" with limitations
+      | limitationType | limitationValue |
+      | Location       | root            |
     And I add policy "content" "create" to "AddLocationRole" with limitations
       | limitationType | limitationValue |
       | ContentType    | Article         |


### PR DESCRIPTION
Follow-up to https://github.com/ibexa/workflow/pull/93

To avoid issues with the lack of taxonomy permissions I'm speciyfing a narrower set of permissions:
1) Only Content Types article and folder are allowed

I should also add Landing Page here, but this fails on lower editions (where the Landing Page CT doesn't exist).
To workaround that I'm using the Location limitation - this will make it possible to read the root location (which is a landing page) without using the landing page identifier.

Regression: https://github.com/ibexa/commerce/pull/635