### PR TITLE
IBX-6507: Adjustments for Solr and Elastic search engines

### DIFF
--- a/.github/workflows/browser-tests.yaml
+++ b/.github/workflows/browser-tests.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
     admin-ui:
         name: "Admin UI tests"
-        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@ibx-6507
         with:
             project-edition: 'oss'
             test-suite:  '--profile=browser --suite=admin-ui-full'
@@ -22,7 +22,7 @@ jobs:
             SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     examples:
         name: "BehatBundle examples"
-        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@ibx-6507
         with:
             project-edition: 'oss'
             test-suite:  '--mode=standard --profile=service --suite=examples'

--- a/.github/workflows/browser-tests.yaml
+++ b/.github/workflows/browser-tests.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
     admin-ui:
         name: "Admin UI tests"
-        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@ibx-6507
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
         with:
             project-edition: 'oss'
             test-suite:  '--profile=browser --suite=admin-ui-full'
@@ -22,7 +22,7 @@ jobs:
             SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     examples:
         name: "BehatBundle examples"
-        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@ibx-6507
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
         with:
             project-edition: 'oss'
             test-suite:  '--mode=standard --profile=service --suite=examples'

--- a/features/setup/multirepository/multirepository.feature
+++ b/features/setup/multirepository/multirepository.feature
@@ -1,6 +1,6 @@
 Feature: Multirepository setup for testing
 
-    @multirepository
+  @multirepository @lse
   Scenario: Set up new repository and make the default one unaccessible
     Given I set configuration to "doctrine.dbal" in "config/packages/doctrine.yaml"
     """

--- a/features/setup/multirepository/multirepository.feature
+++ b/features/setup/multirepository/multirepository.feature
@@ -1,6 +1,6 @@
 Feature: Multirepository setup for testing
 
-  @multirepository @lse
+  @multirepository
   Scenario: Set up new repository and make the default one unaccessible
     Given I set configuration to "doctrine.dbal" in "config/packages/doctrine.yaml"
     """

--- a/features/setup/multirepository/multirepository_elastic.feature
+++ b/features/setup/multirepository/multirepository_elastic.feature
@@ -1,6 +1,6 @@
 Feature: Multirepository setup for testing with Elastic
 
-  @multirepository
+  @multirepository @IbexaContent @IbexaExperience @IbexaCommerce
   Scenario: Set up new connection and make the default one unaccessible
     Given I append configuration to "parameters" in "config/packages/ibexa_elasticsearch.yaml"
     """

--- a/features/setup/multirepository/multirepository_elastic.feature
+++ b/features/setup/multirepository/multirepository_elastic.feature
@@ -1,6 +1,6 @@
 Feature: Multirepository setup for testing with Elastic
 
-  @multirepository @IbexaContent @IbexaExperience @IbexaCommerce
+  @multirepository @elastic
   Scenario: Set up new connection and make the default one unaccessible
     Given I append configuration to "parameters" in "config/packages/ibexa_elasticsearch.yaml"
     """

--- a/features/setup/multirepository/multirepository_elastic.feature
+++ b/features/setup/multirepository/multirepository_elastic.feature
@@ -1,0 +1,17 @@
+Feature: Multirepository setup for testing with Elastic
+
+  @multirepository
+  Scenario: Set up new connection and make the default one unaccessible
+    Given I append configuration to "parameters" in "config/packages/ibexa_elasticsearch.yaml"
+    """
+        elasticsearch_dsn_invalid: "INVALID"
+    """
+    And I set configuration to "ibexa_elasticsearch.connections" in "config/packages/ibexa_elasticsearch.yaml"
+    """
+        default:
+            hosts:
+                - "%elasticsearch_dsn_invalid%"
+        second_connection:
+            hosts:
+                - "%elasticsearch_dsn%"
+    """

--- a/features/setup/multirepository/multirepository_elastic.feature
+++ b/features/setup/multirepository/multirepository_elastic.feature
@@ -1,6 +1,6 @@
 Feature: Multirepository setup for testing with Elastic
 
-  @multirepository @elastic
+  @elastic
   Scenario: Set up new connection and make the default one unaccessible
     Given I append configuration to "parameters" in "config/packages/ibexa_elasticsearch.yaml"
     """

--- a/features/setup/multirepository/multirepository_solr.feature
+++ b/features/setup/multirepository/multirepository_solr.feature
@@ -1,0 +1,30 @@
+Feature: Multirepository setup for testing with Solr
+
+  @multirepository
+  Scenario: Set up new connection and make the default one unaccessible
+    Given I append configuration to "parameters" in "config/packages/ibexa_solr.yaml"
+    """
+        solr_dsn_invalid: 'INVALID'
+        solr_core_invalid: 'INVALID'
+    """
+    And I set configuration to "ibexa_solr" in "config/packages/ibexa_solr.yaml"
+    """
+        endpoints:
+            endpoint0:
+                dsn: '%solr_dsn%'
+                core: '%solr_core%'
+            endpoint1_invalid:
+                dsn: '%solr_dsn_invalid%'
+                core: '%solr_core_invalid%'
+        connections:
+            default:
+                entry_endpoints:
+                    - endpoint1_invalid
+                mapping:
+                    default: endpoint1_invalid
+            second_connection:
+                entry_endpoints:
+                    - endpoint0
+                mapping:
+                    default: endpoint0
+    """

--- a/features/setup/multirepository/multirepository_solr.feature
+++ b/features/setup/multirepository/multirepository_solr.feature
@@ -1,6 +1,6 @@
 Feature: Multirepository setup for testing with Solr
 
-  @multirepository @solr
+  @solr
   Scenario: Set up new connection and make the default one unaccessible
     Given I append configuration to "parameters" in "config/packages/ibexa_solr.yaml"
     """

--- a/features/setup/multirepository/multirepository_solr.feature
+++ b/features/setup/multirepository/multirepository_solr.feature
@@ -1,6 +1,6 @@
 Feature: Multirepository setup for testing with Solr
 
-  @multirepository
+  @multirepository @solr
   Scenario: Set up new connection and make the default one unaccessible
     Given I append configuration to "parameters" in "config/packages/ibexa_solr.yaml"
     """

--- a/src/lib/API/Facade/UserFacade.php
+++ b/src/lib/API/Facade/UserFacade.php
@@ -135,15 +135,21 @@ class UserFacade
             new Criterion\ContentTypeIdentifier(self::USERGROUP_CONTENT_IDENTIFIER),
         ]);
 
-        $result = $this->searchService->findContent($query);
+        $iteration_count = 5;
 
-        foreach ($result->searchHits as $searchHit) {
-            /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Content $content */
-            $content = $searchHit->valueObject;
+        while ($iteration_count > 0) {
+            $result = $this->searchService->findContent($query);
 
-            if ($content->contentInfo->name === $userGroupName) {
-                return $this->userService->loadUserGroup($content->contentInfo->id);
+            foreach ($result->searchHits as $searchHit) {
+                /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Content $content */
+                $content = $searchHit->valueObject;
+
+                if ($content->contentInfo->name === $userGroupName) {
+                    return $this->userService->loadUserGroup($content->contentInfo->id);
+                }
             }
+            usleep(500000);
+            --$iteration_count;
         }
 
         throw new NotFoundException('User Group', $userGroupName);


### PR DESCRIPTION
**JIRA**: [IBX-6507](https://issues.ibexa.co/browse/IBX-6507)

Two things are covered:

1. On Solr newly created user group is not found on first attempt when creating user:
 
```
     And I create a user group "SubtreeEditorsGroup"                                                           
     And I create a user "SubtreeEditor" with last name "Subtree Editor" in group "SubtreeEditorsGroup"      
       Ibexa\Core\Base\Exceptions\NotFoundException: Could not find 'User Group' with identifier 'SubtreeEditorsGroup' in vendor/ibexa/behat/src/lib/API/Facade/UserFacade.php:149
```
 
(e.g. https://github.com/ibexa/content/actions/runs/7300506772/job/19896363930?pr=106)

Loading User Group in User Facade is now retried few times every 0.5 second - https://github.com/ibexa/behat/pull/108/commits/2e606f0fa30fcf498e4e635b5d1d9a01d6b5823f.

2. Solr and Elastic config had to be added to multi repository setup - https://github.com/ibexa/behat/pull/108/commits/175c3d04c5686a30d7770940a09c789676e9d673.

Depends on: https://github.com/ibexa/gh-workflows/pull/48