### PR TITLE
IBX-8139: Dropped class_alias BC layer statements from all classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,9 +54,7 @@
         "psr-4": {
             "Ibexa\\Behat\\": "src/lib/",
             "Ibexa\\Bundle\\Behat\\": "src/bundle/",
-            "Ibexa\\Contracts\\Behat\\": "src/contracts/",
-            "EzSystems\\BehatBundle\\": "src/bundle/",
-            "EzSystems\\Behat\\": "src/lib/"
+            "Ibexa\\Contracts\\Behat\\": "src/contracts/"
         }
     },
     "conflict": {
@@ -65,8 +63,7 @@
     "autoload-dev": {
         "psr-4": {
             "Ibexa\\Tests\\Behat\\": "tests/lib/",
-            "Ibexa\\Tests\\Bundle\\Behat\\": "tests/bundle/",
-            "EzSystems\\Behat\\Test\\": "tests/"
+            "Ibexa\\Tests\\Bundle\\Behat\\": "tests/bundle/"
         }
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "ibexa/behat",
     "description": "Ibexa Behat",
-    "license": "GPL-2.0",
+    "license": "(GPL-2.0-only or proprietary)",
     "replace": {
         "ezsystems/behatbundle": "*"
     },

--- a/src/bundle/Command/CreateExampleDataCommand.php
+++ b/src/bundle/Command/CreateExampleDataCommand.php
@@ -95,5 +95,3 @@ class CreateExampleDataCommand extends Command implements BackwardCompatibleComm
         return ['ezplatform:tools:create-data'];
     }
 }
-
-class_alias(CreateExampleDataCommand::class, 'EzSystems\BehatBundle\Command\CreateExampleDataCommand');

--- a/src/bundle/Command/CreateExampleDataManagerCommand.php
+++ b/src/bundle/Command/CreateExampleDataManagerCommand.php
@@ -167,5 +167,3 @@ class CreateExampleDataManagerCommand extends Command implements BackwardCompati
         return ['ezplatform:tools:generate-items'];
     }
 }
-
-class_alias(CreateExampleDataManagerCommand::class, 'EzSystems\BehatBundle\Command\CreateExampleDataManagerCommand');

--- a/src/bundle/Command/CreateLanguageCommand.php
+++ b/src/bundle/Command/CreateLanguageCommand.php
@@ -83,5 +83,3 @@ class CreateLanguageCommand extends Command implements BackwardCompatibleCommand
         return 0;
     }
 }
-
-class_alias(CreateLanguageCommand::class, 'EzSystems\BehatBundle\Command\CreateLanguageCommand');

--- a/src/bundle/Command/TestSiteaccessCommand.php
+++ b/src/bundle/Command/TestSiteaccessCommand.php
@@ -50,5 +50,3 @@ class TestSiteaccessCommand extends Command implements BackwardCompatibleCommand
         return 0;
     }
 }
-
-class_alias(TestSiteaccessCommand::class, 'EzSystems\BehatBundle\Command\TestSiteaccessCommand');

--- a/src/bundle/Controller/ExceptionController.php
+++ b/src/bundle/Controller/ExceptionController.php
@@ -17,5 +17,3 @@ class ExceptionController
         throw new UnauthorizedException($module, $function, $properties);
     }
 }
-
-class_alias(ExceptionController::class, 'EzSystems\BehatBundle\Controller\ExceptionController');

--- a/src/bundle/Controller/RenderController.php
+++ b/src/bundle/Controller/RenderController.php
@@ -37,5 +37,3 @@ class RenderController extends Controller
         return $view;
     }
 }
-
-class_alias(RenderController::class, 'EzSystems\BehatBundle\Controller\RenderController');

--- a/src/bundle/DependencyInjection/Compiler/ElementFactoryCompilerPass.php
+++ b/src/bundle/DependencyInjection/Compiler/ElementFactoryCompilerPass.php
@@ -36,5 +36,3 @@ class ElementFactoryCompilerPass implements CompilerPassInterface
             $container->getParameter(IbexaBehatExtension::BROWSER_DEBUG_INTERACTIVE_ENABLED);
     }
 }
-
-class_alias(ElementFactoryCompilerPass::class, 'EzSystems\BehatBundle\DependencyInjection\Compiler\ElementFactoryCompilerPass');

--- a/src/bundle/DependencyInjection/Compiler/FieldTypeDataProviderPass.php
+++ b/src/bundle/DependencyInjection/Compiler/FieldTypeDataProviderPass.php
@@ -28,5 +28,3 @@ class FieldTypeDataProviderPass implements CompilerPassInterface
         }
     }
 }
-
-class_alias(FieldTypeDataProviderPass::class, 'EzSystems\BehatBundle\DependencyInjection\Compiler\FieldTypeDataProviderPass');

--- a/src/bundle/DependencyInjection/Compiler/LimitationParserPass.php
+++ b/src/bundle/DependencyInjection/Compiler/LimitationParserPass.php
@@ -28,5 +28,3 @@ class LimitationParserPass implements CompilerPassInterface
         }
     }
 }
-
-class_alias(LimitationParserPass::class, 'EzSystems\BehatBundle\DependencyInjection\Compiler\LimitationParserPass');

--- a/src/bundle/DependencyInjection/IbexaBehatExtension.php
+++ b/src/bundle/DependencyInjection/IbexaBehatExtension.php
@@ -83,5 +83,3 @@ class IbexaBehatExtension extends Extension implements PrependExtensionInterface
         return isset($bundles['IbexaPageBuilderBundle'], $bundles['IbexaWorkflowBundle']);
     }
 }
-
-class_alias(IbexaBehatExtension::class, 'EzSystems\BehatBundle\DependencyInjection\eZBehatExtension');

--- a/src/bundle/IbexaBehatBundle.php
+++ b/src/bundle/IbexaBehatBundle.php
@@ -23,5 +23,3 @@ class IbexaBehatBundle extends Bundle
         $container->addCompilerPass(new ElementFactoryCompilerPass());
     }
 }
-
-class_alias(IbexaBehatBundle::class, 'EzSystems\BehatBundle\EzSystemsBehatBundle');

--- a/src/bundle/IbexaExtension.php
+++ b/src/bundle/IbexaExtension.php
@@ -123,5 +123,3 @@ class IbexaExtension implements Extension
         return '%' . $name . '%';
     }
 }
-
-class_alias(IbexaExtension::class, 'EzSystems\BehatBundle\BehatExtension');

--- a/src/bundle/Initializer/BehatSiteAccessInitializer.php
+++ b/src/bundle/Initializer/BehatSiteAccessInitializer.php
@@ -59,5 +59,3 @@ final class BehatSiteAccessInitializer implements EventSubscriberInterface
         return new SiteAccess($siteAccessName, 'cli');
     }
 }
-
-class_alias(BehatSiteAccessInitializer::class, 'EzSystems\BehatBundle\Initializer\BehatSiteAccessInitializer');

--- a/src/bundle/Templating/Twig/PHPTypeExtension.php
+++ b/src/bundle/Templating/Twig/PHPTypeExtension.php
@@ -28,5 +28,3 @@ class PHPTypeExtension extends AbstractExtension
         ];
     }
 }
-
-class_alias(PHPTypeExtension::class, 'EzSystems\BehatBundle\Templating\Twig\PHPTypeExtension');

--- a/src/lib/API/ContentData/ContentDataProvider.php
+++ b/src/lib/API/ContentData/ContentDataProvider.php
@@ -115,5 +115,3 @@ class ContentDataProvider
         return $contentStruct;
     }
 }
-
-class_alias(ContentDataProvider::class, 'EzSystems\Behat\API\ContentData\ContentDataProvider');

--- a/src/lib/API/ContentData/FieldTypeData/AbstractFieldTypeDataProvider.php
+++ b/src/lib/API/ContentData/FieldTypeData/AbstractFieldTypeDataProvider.php
@@ -35,5 +35,3 @@ abstract class AbstractFieldTypeDataProvider implements FieldTypeDataProviderInt
         return $this->randomDataGenerator->getFaker();
     }
 }
-
-class_alias(AbstractFieldTypeDataProvider::class, 'EzSystems\Behat\API\ContentData\FieldTypeData\AbstractFieldTypeDataProvider');

--- a/src/lib/API/ContentData/FieldTypeData/AuthorDataProvider.php
+++ b/src/lib/API/ContentData/FieldTypeData/AuthorDataProvider.php
@@ -45,5 +45,3 @@ class AuthorDataProvider extends AbstractFieldTypeDataProvider
         return $author;
     }
 }
-
-class_alias(AuthorDataProvider::class, 'EzSystems\Behat\API\ContentData\FieldTypeData\AuthorDataProvider');

--- a/src/lib/API/ContentData/FieldTypeData/BinaryFileDataProvider.php
+++ b/src/lib/API/ContentData/FieldTypeData/BinaryFileDataProvider.php
@@ -45,5 +45,3 @@ class BinaryFileDataProvider implements FieldTypeDataProviderInterface
         return new Value(['inputUri' => $filePath]);
     }
 }
-
-class_alias(BinaryFileDataProvider::class, 'EzSystems\Behat\API\ContentData\FieldTypeData\BinaryFileDataProvider');

--- a/src/lib/API/ContentData/FieldTypeData/BooleanDataProvider.php
+++ b/src/lib/API/ContentData/FieldTypeData/BooleanDataProvider.php
@@ -43,5 +43,3 @@ class BooleanDataProvider extends AbstractFieldTypeDataProvider
         return 'true' === strtolower($value);
     }
 }
-
-class_alias(BooleanDataProvider::class, 'EzSystems\Behat\API\ContentData\FieldTypeData\BooleanDataProvider');

--- a/src/lib/API/ContentData/FieldTypeData/CountryDataProvider.php
+++ b/src/lib/API/ContentData/FieldTypeData/CountryDataProvider.php
@@ -44,5 +44,3 @@ class CountryDataProvider implements FieldTypeDataProviderInterface
         return new Value([$value => self::COUNTRY_DATA[$value]]);
     }
 }
-
-class_alias(CountryDataProvider::class, 'EzSystems\Behat\API\ContentData\FieldTypeData\CountryDataProvider');

--- a/src/lib/API/ContentData/FieldTypeData/DateDataProvider.php
+++ b/src/lib/API/ContentData/FieldTypeData/DateDataProvider.php
@@ -28,5 +28,3 @@ class DateDataProvider extends AbstractFieldTypeDataProvider
         return DateTime::createFromFormat('Y-m-d', $value);
     }
 }
-
-class_alias(DateDataProvider::class, 'EzSystems\Behat\API\ContentData\FieldTypeData\DateDataProvider');

--- a/src/lib/API/ContentData/FieldTypeData/DateTimeDataProvider.php
+++ b/src/lib/API/ContentData/FieldTypeData/DateTimeDataProvider.php
@@ -28,5 +28,3 @@ class DateTimeDataProvider extends AbstractFieldTypeDataProvider
         return DateTime::createFromFormat('Y-m-d H:i:s', $value);
     }
 }
-
-class_alias(DateTimeDataProvider::class, 'EzSystems\Behat\API\ContentData\FieldTypeData\DateTimeDataProvider');

--- a/src/lib/API/ContentData/FieldTypeData/EmailDataProvider.php
+++ b/src/lib/API/ContentData/FieldTypeData/EmailDataProvider.php
@@ -22,5 +22,3 @@ class EmailDataProvider extends AbstractFieldTypeDataProvider
         return $this->getFaker()->companyEmail;
     }
 }
-
-class_alias(EmailDataProvider::class, 'EzSystems\Behat\API\ContentData\FieldTypeData\EmailDataProvider');

--- a/src/lib/API/ContentData/FieldTypeData/FieldTypeDataProviderInterface.php
+++ b/src/lib/API/ContentData/FieldTypeData/FieldTypeDataProviderInterface.php
@@ -16,5 +16,3 @@ interface FieldTypeDataProviderInterface
 
     public function parseFromString(string $value);
 }
-
-class_alias(FieldTypeDataProviderInterface::class, 'EzSystems\Behat\API\ContentData\FieldTypeData\FieldTypeDataProviderInterface');

--- a/src/lib/API/ContentData/FieldTypeData/FloatDataProvider.php
+++ b/src/lib/API/ContentData/FieldTypeData/FloatDataProvider.php
@@ -25,5 +25,3 @@ class FloatDataProvider extends AbstractFieldTypeDataProvider
         return (float) $value;
     }
 }
-
-class_alias(FloatDataProvider::class, 'EzSystems\Behat\API\ContentData\FieldTypeData\FloatDataProvider');

--- a/src/lib/API/ContentData/FieldTypeData/ISBNDataProvider.php
+++ b/src/lib/API/ContentData/FieldTypeData/ISBNDataProvider.php
@@ -20,5 +20,3 @@ class ISBNDataProvider extends AbstractFieldTypeDataProvider
         return $this->getFaker()->isbn13;
     }
 }
-
-class_alias(ISBNDataProvider::class, 'EzSystems\Behat\API\ContentData\FieldTypeData\ISBNDataProvider');

--- a/src/lib/API/ContentData/FieldTypeData/ImageAssetDataProvider.php
+++ b/src/lib/API/ContentData/FieldTypeData/ImageAssetDataProvider.php
@@ -99,5 +99,3 @@ class ImageAssetDataProvider extends AbstractFieldTypeDataProvider
         return new Value($location->getContentInfo()->id, $this->getFaker()->realText(100));
     }
 }
-
-class_alias(ImageAssetDataProvider::class, 'EzSystems\Behat\API\ContentData\FieldTypeData\ImageAssetDataProvider');

--- a/src/lib/API/ContentData/FieldTypeData/ImageDataProvider.php
+++ b/src/lib/API/ContentData/FieldTypeData/ImageDataProvider.php
@@ -70,5 +70,3 @@ class ImageDataProvider extends AbstractFieldTypeDataProvider
         );
     }
 }
-
-class_alias(ImageDataProvider::class, 'EzSystems\Behat\API\ContentData\FieldTypeData\ImageDataProvider');

--- a/src/lib/API/ContentData/FieldTypeData/IntegerDataProvider.php
+++ b/src/lib/API/ContentData/FieldTypeData/IntegerDataProvider.php
@@ -25,5 +25,3 @@ class IntegerDataProvider extends AbstractFieldTypeDataProvider
         return (int) $value;
     }
 }
-
-class_alias(IntegerDataProvider::class, 'EzSystems\Behat\API\ContentData\FieldTypeData\IntegerDataProvider');

--- a/src/lib/API/ContentData/FieldTypeData/MapDataProvider.php
+++ b/src/lib/API/ContentData/FieldTypeData/MapDataProvider.php
@@ -50,5 +50,3 @@ class MapDataProvider implements FieldTypeDataProviderInterface
         return new Value(self::LOCATION_DATA[$value]);
     }
 }
-
-class_alias(MapDataProvider::class, 'EzSystems\Behat\API\ContentData\FieldTypeData\MapDataProvider');

--- a/src/lib/API/ContentData/FieldTypeData/MatrixDataProvider.php
+++ b/src/lib/API/ContentData/FieldTypeData/MatrixDataProvider.php
@@ -92,5 +92,3 @@ class MatrixDataProvider extends AbstractFieldTypeDataProvider
         return new Row($values);
     }
 }
-
-class_alias(MatrixDataProvider::class, 'EzSystems\Behat\API\ContentData\FieldTypeData\MatrixDataProvider');

--- a/src/lib/API/ContentData/FieldTypeData/MediaDataProvider.php
+++ b/src/lib/API/ContentData/FieldTypeData/MediaDataProvider.php
@@ -55,5 +55,3 @@ class MediaDataProvider implements FieldTypeDataProviderInterface
         return $mediaValue;
     }
 }
-
-class_alias(MediaDataProvider::class, 'EzSystems\Behat\API\ContentData\FieldTypeData\MediaDataProvider');

--- a/src/lib/API/ContentData/FieldTypeData/ObjectRelationDataProvider.php
+++ b/src/lib/API/ContentData/FieldTypeData/ObjectRelationDataProvider.php
@@ -66,5 +66,3 @@ class ObjectRelationDataProvider implements FieldTypeDataProviderInterface
         return $location->getContentInfo()->id;
     }
 }
-
-class_alias(ObjectRelationDataProvider::class, 'EzSystems\Behat\API\ContentData\FieldTypeData\ObjectRelationDataProvider');

--- a/src/lib/API/ContentData/FieldTypeData/ObjectRelationListDataProvider.php
+++ b/src/lib/API/ContentData/FieldTypeData/ObjectRelationListDataProvider.php
@@ -32,5 +32,3 @@ class ObjectRelationListDataProvider extends ObjectRelationDataProvider
         return new Value($itemsToAdd);
     }
 }
-
-class_alias(ObjectRelationListDataProvider::class, 'EzSystems\Behat\API\ContentData\FieldTypeData\ObjectRelationListDataProvider');

--- a/src/lib/API/ContentData/FieldTypeData/PasswordProvider.php
+++ b/src/lib/API/ContentData/FieldTypeData/PasswordProvider.php
@@ -22,5 +22,3 @@ class PasswordProvider extends AbstractFieldTypeDataProvider
         return self::DEFAUlT_PASSWORD;
     }
 }
-
-class_alias(PasswordProvider::class, 'EzSystems\Behat\API\ContentData\FieldTypeData\PasswordProvider');

--- a/src/lib/API/ContentData/FieldTypeData/RichTextDataProvider.php
+++ b/src/lib/API/ContentData/FieldTypeData/RichTextDataProvider.php
@@ -62,5 +62,3 @@ class RichTextDataProvider extends AbstractFieldTypeDataProvider
         return sprintf(self::SIMPLE_RICHTEXT_XML, $value);
     }
 }
-
-class_alias(RichTextDataProvider::class, 'EzSystems\Behat\API\ContentData\FieldTypeData\RichTextDataProvider');

--- a/src/lib/API/ContentData/FieldTypeData/SelectionDataProvider.php
+++ b/src/lib/API/ContentData/FieldTypeData/SelectionDataProvider.php
@@ -50,5 +50,3 @@ class SelectionDataProvider implements FieldTypeDataProviderInterface
         return new Value($options);
     }
 }
-
-class_alias(SelectionDataProvider::class, 'EzSystems\Behat\API\ContentData\FieldTypeData\SelectionDataProvider');

--- a/src/lib/API/ContentData/FieldTypeData/TextBlockDataProvider.php
+++ b/src/lib/API/ContentData/FieldTypeData/TextBlockDataProvider.php
@@ -22,5 +22,3 @@ class TextBlockDataProvider extends AbstractFieldTypeDataProvider
         return $this->getFaker()->paragraphs(5, true);
     }
 }
-
-class_alias(TextBlockDataProvider::class, 'EzSystems\Behat\API\ContentData\FieldTypeData\TextBlockDataProvider');

--- a/src/lib/API/ContentData/FieldTypeData/TextLineDataProvider.php
+++ b/src/lib/API/ContentData/FieldTypeData/TextLineDataProvider.php
@@ -29,5 +29,3 @@ class TextLineDataProvider extends AbstractFieldTypeDataProvider
         return new Value($value);
     }
 }
-
-class_alias(TextLineDataProvider::class, 'EzSystems\Behat\API\ContentData\FieldTypeData\TextLineDataProvider');

--- a/src/lib/API/ContentData/FieldTypeData/TimeDataProvider.php
+++ b/src/lib/API/ContentData/FieldTypeData/TimeDataProvider.php
@@ -28,5 +28,3 @@ class TimeDataProvider extends AbstractFieldTypeDataProvider
         return Value::fromDateTime(DateTime::createFromFormat('H:i:s', $value));
     }
 }
-
-class_alias(TimeDataProvider::class, 'EzSystems\Behat\API\ContentData\FieldTypeData\TimeDataProvider');

--- a/src/lib/API/ContentData/FieldTypeData/URLDataProvider.php
+++ b/src/lib/API/ContentData/FieldTypeData/URLDataProvider.php
@@ -31,5 +31,3 @@ class URLDataProvider extends AbstractFieldTypeDataProvider
         return new Value($url, $text);
     }
 }
-
-class_alias(URLDataProvider::class, 'EzSystems\Behat\API\ContentData\FieldTypeData\URLDataProvider');

--- a/src/lib/API/ContentData/FieldTypeNameConverter.php
+++ b/src/lib/API/ContentData/FieldTypeNameConverter.php
@@ -54,5 +54,3 @@ class FieldTypeNameConverter
         return array_search($fieldTypeName, static::$FIELD_TYPE_MAPPING);
     }
 }
-
-class_alias(FieldTypeNameConverter::class, 'EzSystems\Behat\API\ContentData\FieldTypeNameConverter');

--- a/src/lib/API/ContentData/RandomDataGenerator.php
+++ b/src/lib/API/ContentData/RandomDataGenerator.php
@@ -69,5 +69,3 @@ class RandomDataGenerator
         return random_int(0, 999) / 1000;
     }
 }
-
-class_alias(RandomDataGenerator::class, 'EzSystems\Behat\API\ContentData\RandomDataGenerator');

--- a/src/lib/API/Context/ContentContext.php
+++ b/src/lib/API/Context/ContentContext.php
@@ -142,5 +142,3 @@ class ContentContext implements Context
         return $contentItemData->getHash();
     }
 }
-
-class_alias(ContentContext::class, 'EzSystems\Behat\API\Context\ContentContext');

--- a/src/lib/API/Context/ContentTypeContext.php
+++ b/src/lib/API/Context/ContentTypeContext.php
@@ -149,5 +149,3 @@ class ContentTypeContext implements Context
         return ['taxonomy' => $settings];
     }
 }
-
-class_alias(ContentTypeContext::class, 'EzSystems\Behat\API\Context\ContentTypeContext');

--- a/src/lib/API/Context/LanguageContext.php
+++ b/src/lib/API/Context/LanguageContext.php
@@ -31,5 +31,3 @@ class LanguageContext implements Context
         $this->languageFacade->createLanguageIfNotExists($name, $languageCode);
     }
 }
-
-class_alias(LanguageContext::class, 'EzSystems\Behat\API\Context\LanguageContext');

--- a/src/lib/API/Context/LimitationParser/ContentTypeLimitationParser.php
+++ b/src/lib/API/Context/LimitationParser/ContentTypeLimitationParser.php
@@ -64,5 +64,3 @@ class ContentTypeLimitationParser implements LimitationParserInterface
         return $contentTypeName;
     }
 }
-
-class_alias(ContentTypeLimitationParser::class, 'EzSystems\Behat\API\Context\LimitationParser\ContentTypeLimitationParser');

--- a/src/lib/API/Context/LimitationParser/FieldGroupLimitationParser.php
+++ b/src/lib/API/Context/LimitationParser/FieldGroupLimitationParser.php
@@ -27,5 +27,3 @@ class FieldGroupLimitationParser implements LimitationParserInterface
         );
     }
 }
-
-class_alias(FieldGroupLimitationParser::class, 'EzSystems\Behat\API\Context\LimitationParser\FieldGroupLimitationParser');

--- a/src/lib/API/Context/LimitationParser/LanguageLimitationParser.php
+++ b/src/lib/API/Context/LimitationParser/LanguageLimitationParser.php
@@ -25,5 +25,3 @@ class LanguageLimitationParser implements LimitationParserInterface
         );
     }
 }
-
-class_alias(LanguageLimitationParser::class, 'EzSystems\Behat\API\Context\LimitationParser\LanguageLimitationParser');

--- a/src/lib/API/Context/LimitationParser/LimitationParserInterface.php
+++ b/src/lib/API/Context/LimitationParser/LimitationParserInterface.php
@@ -16,5 +16,3 @@ interface LimitationParserInterface
 
     public function parse(string $limitationValues): Limitation;
 }
-
-class_alias(LimitationParserInterface::class, 'EzSystems\Behat\API\Context\LimitationParser\LimitationParserInterface');

--- a/src/lib/API/Context/LimitationParser/LimitationParsersCollector.php
+++ b/src/lib/API/Context/LimitationParser/LimitationParsersCollector.php
@@ -34,5 +34,3 @@ class LimitationParsersCollector
         return $this->limitationParsers;
     }
 }
-
-class_alias(LimitationParsersCollector::class, 'EzSystems\Behat\API\Context\LimitationParser\LimitationParsersCollector');

--- a/src/lib/API/Context/LimitationParser/LocationLimitationParser.php
+++ b/src/lib/API/Context/LimitationParser/LocationLimitationParser.php
@@ -56,5 +56,3 @@ class LocationLimitationParser implements LimitationParserInterface
         );
     }
 }
-
-class_alias(LocationLimitationParser::class, 'EzSystems\Behat\API\Context\LimitationParser\LocationLimitationParser');

--- a/src/lib/API/Context/LimitationParser/NewSectionLimitationParser.php
+++ b/src/lib/API/Context/LimitationParser/NewSectionLimitationParser.php
@@ -43,5 +43,3 @@ class NewSectionLimitationParser implements LimitationParserInterface
         );
     }
 }
-
-class_alias(NewSectionLimitationParser::class, 'EzSystems\Behat\API\Context\LimitationParser\NewSectionLimitationParser');

--- a/src/lib/API/Context/LimitationParser/NewStateLimitationParser.php
+++ b/src/lib/API/Context/LimitationParser/NewStateLimitationParser.php
@@ -60,5 +60,3 @@ class NewStateLimitationParser implements LimitationParserInterface
         return $values;
     }
 }
-
-class_alias(NewStateLimitationParser::class, 'EzSystems\Behat\API\Context\LimitationParser\NewStateLimitationParser');

--- a/src/lib/API/Context/LimitationParser/ObjectStateLimitationParser.php
+++ b/src/lib/API/Context/LimitationParser/ObjectStateLimitationParser.php
@@ -27,5 +27,3 @@ class ObjectStateLimitationParser extends NewStateLimitationParser implements Li
         );
     }
 }
-
-class_alias(ObjectStateLimitationParser::class, 'EzSystems\Behat\API\Context\LimitationParser\ObjectStateLimitationParser');

--- a/src/lib/API/Context/LimitationParser/OwnerLimitationParser.php
+++ b/src/lib/API/Context/LimitationParser/OwnerLimitationParser.php
@@ -30,5 +30,3 @@ class OwnerLimitationParser implements LimitationParserInterface
         );
     }
 }
-
-class_alias(OwnerLimitationParser::class, 'EzSystems\Behat\API\Context\LimitationParser\OwnerLimitationParser');

--- a/src/lib/API/Context/LimitationParser/ParentContentTypeLimitationParser.php
+++ b/src/lib/API/Context/LimitationParser/ParentContentTypeLimitationParser.php
@@ -26,5 +26,3 @@ class ParentContentTypeLimitationParser extends ContentTypeLimitationParser
         );
     }
 }
-
-class_alias(ParentContentTypeLimitationParser::class, 'EzSystems\Behat\API\Context\LimitationParser\ParentContentTypeLimitationParser');

--- a/src/lib/API/Context/LimitationParser/ParentDepthLimitationParser.php
+++ b/src/lib/API/Context/LimitationParser/ParentDepthLimitationParser.php
@@ -25,5 +25,3 @@ class ParentDepthLimitationParser implements LimitationParserInterface
         );
     }
 }
-
-class_alias(ParentDepthLimitationParser::class, 'EzSystems\Behat\API\Context\LimitationParser\ParentDepthLimitationParser');

--- a/src/lib/API/Context/LimitationParser/ParentOwnerLimitationParser.php
+++ b/src/lib/API/Context/LimitationParser/ParentOwnerLimitationParser.php
@@ -31,5 +31,3 @@ class ParentOwnerLimitationParser implements LimitationParserInterface
         );
     }
 }
-
-class_alias(ParentOwnerLimitationParser::class, 'EzSystems\Behat\API\Context\LimitationParser\ParentOwnerLimitationParser');

--- a/src/lib/API/Context/LimitationParser/ParentUserGroupLimitationParser.php
+++ b/src/lib/API/Context/LimitationParser/ParentUserGroupLimitationParser.php
@@ -31,5 +31,3 @@ class ParentUserGroupLimitationParser implements LimitationParserInterface
         );
     }
 }
-
-class_alias(ParentUserGroupLimitationParser::class, 'EzSystems\Behat\API\Context\LimitationParser\ParentUserGroupLimitationParser');

--- a/src/lib/API/Context/LimitationParser/SectionLimitationParser.php
+++ b/src/lib/API/Context/LimitationParser/SectionLimitationParser.php
@@ -43,5 +43,3 @@ class SectionLimitationParser implements LimitationParserInterface
         );
     }
 }
-
-class_alias(SectionLimitationParser::class, 'EzSystems\Behat\API\Context\LimitationParser\SectionLimitationParser');

--- a/src/lib/API/Context/LimitationParser/SiteaccessLimitationParser.php
+++ b/src/lib/API/Context/LimitationParser/SiteaccessLimitationParser.php
@@ -32,5 +32,3 @@ class SiteaccessLimitationParser implements LimitationParserInterface
         );
     }
 }
-
-class_alias(SiteaccessLimitationParser::class, 'EzSystems\Behat\API\Context\LimitationParser\SiteaccessLimitationParser');

--- a/src/lib/API/Context/LimitationParser/SubtreeLimitationParser.php
+++ b/src/lib/API/Context/LimitationParser/SubtreeLimitationParser.php
@@ -45,5 +45,3 @@ class SubtreeLimitationParser implements LimitationParserInterface
         );
     }
 }
-
-class_alias(SubtreeLimitationParser::class, 'EzSystems\Behat\API\Context\LimitationParser\SubtreeLimitationParser');

--- a/src/lib/API/Context/LimitationParser/UserGroupLimitationParser.php
+++ b/src/lib/API/Context/LimitationParser/UserGroupLimitationParser.php
@@ -30,5 +30,3 @@ class UserGroupLimitationParser implements LimitationParserInterface
         );
     }
 }
-
-class_alias(UserGroupLimitationParser::class, 'EzSystems\Behat\API\Context\LimitationParser\UserGroupLimitationParser');

--- a/src/lib/API/Context/LimitationParser/WorkflowStageLimitationParser.php
+++ b/src/lib/API/Context/LimitationParser/WorkflowStageLimitationParser.php
@@ -27,5 +27,3 @@ class WorkflowStageLimitationParser implements LimitationParserInterface
         );
     }
 }
-
-class_alias(WorkflowStageLimitationParser::class, 'EzSystems\Behat\API\Context\LimitationParser\WorkflowStageLimitationParser');

--- a/src/lib/API/Context/LimitationParser/WorkflowTransitionLimitationParser.php
+++ b/src/lib/API/Context/LimitationParser/WorkflowTransitionLimitationParser.php
@@ -27,5 +27,3 @@ class WorkflowTransitionLimitationParser implements LimitationParserInterface
         );
     }
 }
-
-class_alias(WorkflowTransitionLimitationParser::class, 'EzSystems\Behat\API\Context\LimitationParser\WorkflowTransitionLimitationParser');

--- a/src/lib/API/Context/ObjectStateContext.php
+++ b/src/lib/API/Context/ObjectStateContext.php
@@ -46,5 +46,3 @@ class ObjectStateContext implements Context
         }
     }
 }
-
-class_alias(ObjectStateContext::class, 'EzSystems\Behat\API\Context\ObjectStateContext');

--- a/src/lib/API/Context/RoleContext.php
+++ b/src/lib/API/Context/RoleContext.php
@@ -78,5 +78,3 @@ class RoleContext implements Context
         $this->roleFacade->addPolicyToRole($roleName, $module, $function, $parsedLimitations);
     }
 }
-
-class_alias(RoleContext::class, 'EzSystems\Behat\API\Context\RoleContext');

--- a/src/lib/API/Context/TestContext.php
+++ b/src/lib/API/Context/TestContext.php
@@ -41,5 +41,3 @@ class TestContext implements Context
         $this->iAmLoggedAsApiUser('admin');
     }
 }
-
-class_alias(TestContext::class, 'EzSystems\Behat\API\Context\TestContext');

--- a/src/lib/API/Context/TrashContext.php
+++ b/src/lib/API/Context/TrashContext.php
@@ -37,5 +37,3 @@ class TrashContext implements Context
         $this->trashFacade->trash($locationURL);
     }
 }
-
-class_alias(TrashContext::class, 'EzSystems\Behat\API\Context\TrashContext');

--- a/src/lib/API/Context/UserContext.php
+++ b/src/lib/API/Context/UserContext.php
@@ -94,5 +94,3 @@ class UserContext implements Context
         $this->userFacade->assignUserGroupToRole($userGroupName, $roleName, $roleLimitation);
     }
 }
-
-class_alias(UserContext::class, 'EzSystems\Behat\API\Context\UserContext');

--- a/src/lib/API/Facade/ContentFacade.php
+++ b/src/lib/API/Facade/ContentFacade.php
@@ -150,5 +150,3 @@ class ContentFacade
         }
     }
 }
-
-class_alias(ContentFacade::class, 'EzSystems\Behat\API\Facade\ContentFacade');

--- a/src/lib/API/Facade/ContentTypeFacade.php
+++ b/src/lib/API/Facade/ContentTypeFacade.php
@@ -114,5 +114,3 @@ class ContentTypeFacade
         }
     }
 }
-
-class_alias(ContentTypeFacade::class, 'EzSystems\Behat\API\Facade\ContentTypeFacade');

--- a/src/lib/API/Facade/LanguageFacade.php
+++ b/src/lib/API/Facade/LanguageFacade.php
@@ -39,5 +39,3 @@ class LanguageFacade
         $this->languageService->createLanguage($languageCreateStruct);
     }
 }
-
-class_alias(LanguageFacade::class, 'EzSystems\Behat\API\Facade\LanguageFacade');

--- a/src/lib/API/Facade/RoleFacade.php
+++ b/src/lib/API/Facade/RoleFacade.php
@@ -69,5 +69,3 @@ class RoleFacade
         return $this->limitationParsersCollector->getLimitationParsers();
     }
 }
-
-class_alias(RoleFacade::class, 'EzSystems\Behat\API\Facade\RoleFacade');

--- a/src/lib/API/Facade/SearchFacade.php
+++ b/src/lib/API/Facade/SearchFacade.php
@@ -104,5 +104,3 @@ class SearchFacade
         return $this->contentService->loadContent($contentId)->contentInfo->mainLocationId;
     }
 }
-
-class_alias(SearchFacade::class, 'EzSystems\Behat\API\Facade\SearchFacade');

--- a/src/lib/API/Facade/TrashFacade.php
+++ b/src/lib/API/Facade/TrashFacade.php
@@ -42,5 +42,3 @@ class TrashFacade
         $this->trashService->trash($location);
     }
 }
-
-class_alias(TrashFacade::class, 'EzSystems\Behat\API\Facade\TrashFacade');

--- a/src/lib/API/Facade/UserFacade.php
+++ b/src/lib/API/Facade/UserFacade.php
@@ -155,5 +155,3 @@ class UserFacade
         throw new NotFoundException('User Group', $userGroupName);
     }
 }
-
-class_alias(UserFacade::class, 'EzSystems\Behat\API\Facade\UserFacade');

--- a/src/lib/Core/Behat/ArgumentParser.php
+++ b/src/lib/Core/Behat/ArgumentParser.php
@@ -77,5 +77,3 @@ class ArgumentParser
         return str_replace(self::ROOT_KEYWORD, $this->parameterProvider->getParameter('root_content_name'), $path);
     }
 }
-
-class_alias(ArgumentParser::class, 'EzSystems\Behat\Core\Behat\ArgumentParser');

--- a/src/lib/Core/Behat/TableNodeExtension.php
+++ b/src/lib/Core/Behat/TableNodeExtension.php
@@ -62,5 +62,3 @@ class TableNodeExtension extends TableNode
         return new self($newTable);
     }
 }
-
-class_alias(TableNodeExtension::class, 'EzSystems\Behat\Core\Behat\TableNodeExtension');

--- a/src/lib/Core/Configuration/ConfigurationEditor.php
+++ b/src/lib/Core/Configuration/ConfigurationEditor.php
@@ -125,5 +125,3 @@ class ConfigurationEditor implements ConfigurationEditorInterface
         return $config;
     }
 }
-
-class_alias(ConfigurationEditor::class, 'EzSystems\Behat\Core\Configuration\ConfigurationEditor');

--- a/src/lib/Core/Configuration/ConfigurationEditorInterface.php
+++ b/src/lib/Core/Configuration/ConfigurationEditorInterface.php
@@ -47,5 +47,3 @@ interface ConfigurationEditorInterface
 
     public function copyKey($config, string $keyName, string $newKeyName);
 }
-
-class_alias(ConfigurationEditorInterface::class, 'EzSystems\Behat\Core\Configuration\ConfigurationEditorInterface');

--- a/src/lib/Core/Configuration/LocationAwareConfigurationEditor.php
+++ b/src/lib/Core/Configuration/LocationAwareConfigurationEditor.php
@@ -83,5 +83,3 @@ class LocationAwareConfigurationEditor implements ConfigurationEditorInterface
         return $this->resolveLocationReference($config);
     }
 }
-
-class_alias(LocationAwareConfigurationEditor::class, 'EzSystems\Behat\Core\Configuration\LocationAwareConfigurationEditor');

--- a/src/lib/Core/Context/ConfigurationContext.php
+++ b/src/lib/Core/Context/ConfigurationContext.php
@@ -168,5 +168,3 @@ class ConfigurationContext implements Context
         $this->configurationEditor->saveConfigToFile($configFilePath, $config);
     }
 }
-
-class_alias(ConfigurationContext::class, 'EzSystems\Behat\Core\Context\ConfigurationContext');

--- a/src/lib/Core/Context/FileContext.php
+++ b/src/lib/Core/Context/FileContext.php
@@ -83,5 +83,3 @@ class FileContext implements Context
         }
     }
 }
-
-class_alias(FileContext::class, 'EzSystems\Behat\Core\Context\FileContext');

--- a/src/lib/Core/Context/TimeContext.php
+++ b/src/lib/Core/Context/TimeContext.php
@@ -62,5 +62,3 @@ class TimeContext implements Context
         Assert::assertGreaterThan($maxDuration, $actualDuration);
     }
 }
-
-class_alias(TimeContext::class, 'EzSystems\Behat\Core\Context\TimeContext');

--- a/src/lib/Core/Debug/Command/GoBackCommand.php
+++ b/src/lib/Core/Debug/Command/GoBackCommand.php
@@ -42,5 +42,3 @@ class GoBackCommand extends Command
         return 0;
     }
 }
-
-class_alias(GoBackCommand::class, 'EzSystems\Behat\Core\Debug\Command\GoBackCommand');

--- a/src/lib/Core/Debug/Command/RefreshPageCommand.php
+++ b/src/lib/Core/Debug/Command/RefreshPageCommand.php
@@ -42,5 +42,3 @@ class RefreshPageCommand extends Command
         return 0;
     }
 }
-
-class_alias(RefreshPageCommand::class, 'EzSystems\Behat\Core\Debug\Command\RefreshPageCommand');

--- a/src/lib/Core/Debug/Command/ShowHTMLCommand.php
+++ b/src/lib/Core/Debug/Command/ShowHTMLCommand.php
@@ -40,5 +40,3 @@ class ShowHTMLCommand extends Command
         return 0;
     }
 }
-
-class_alias(ShowHTMLCommand::class, 'EzSystems\Behat\Core\Debug\Command\ShowHTMLCommand');

--- a/src/lib/Core/Debug/Command/ShowURLCommand.php
+++ b/src/lib/Core/Debug/Command/ShowURLCommand.php
@@ -40,5 +40,3 @@ class ShowURLCommand extends Command
         return 0;
     }
 }
-
-class_alias(ShowURLCommand::class, 'EzSystems\Behat\Core\Debug\Command\ShowURLCommand');

--- a/src/lib/Core/Debug/Command/TakeScreenshotCommand.php
+++ b/src/lib/Core/Debug/Command/TakeScreenshotCommand.php
@@ -62,5 +62,3 @@ class TakeScreenshotCommand extends Command
         }
     }
 }
-
-class_alias(TakeScreenshotCommand::class, 'EzSystems\Behat\Core\Debug\Command\TakeScreenshotCommand');

--- a/src/lib/Core/Debug/InteractiveDebuggerTrait.php
+++ b/src/lib/Core/Debug/InteractiveDebuggerTrait.php
@@ -131,5 +131,3 @@ trait InteractiveDebuggerTrait
         ]);
     }
 }
-
-class_alias(InteractiveDebuggerTrait::class, 'EzSystems\Behat\Core\Debug\InteractiveDebuggerTrait');

--- a/src/lib/Core/Debug/Matcher/ObjectFunctionCallChainMatcher.php
+++ b/src/lib/Core/Debug/Matcher/ObjectFunctionCallChainMatcher.php
@@ -117,5 +117,3 @@ class ObjectFunctionCallChainMatcher extends ObjectMethodsMatcher
         return get_class($object);
     }
 }
-
-class_alias(ObjectFunctionCallChainMatcher::class, 'EzSystems\Behat\Core\Debug\Matcher\ObjectFunctionCallChainMatcher');

--- a/src/lib/Core/Debug/Matcher/ThisObjectMethodsMatcher.php
+++ b/src/lib/Core/Debug/Matcher/ThisObjectMethodsMatcher.php
@@ -54,5 +54,3 @@ class ThisObjectMethodsMatcher extends ObjectMethodsMatcher
         ));
     }
 }
-
-class_alias(ThisObjectMethodsMatcher::class, 'EzSystems\Behat\Core\Debug\Matcher\ThisObjectMethodsMatcher');

--- a/src/lib/Core/Debug/Shell/Shell.php
+++ b/src/lib/Core/Debug/Shell/Shell.php
@@ -77,5 +77,3 @@ class Shell extends BaseShell
         $this->writeMessage('The error message is: ' . $e->getMessage());
     }
 }
-
-class_alias(Shell::class, 'EzSystems\Behat\Core\Debug\Shell\Shell');

--- a/src/lib/Core/Log/LogFileReader.php
+++ b/src/lib/Core/Log/LogFileReader.php
@@ -40,5 +40,3 @@ class LogFileReader
         return $logEntries;
     }
 }
-
-class_alias(LogFileReader::class, 'EzSystems\Behat\Core\Log\LogFileReader');

--- a/src/lib/Core/Log/TestLogProvider.php
+++ b/src/lib/Core/Log/TestLogProvider.php
@@ -108,5 +108,3 @@ final class TestLogProvider
         self::$LOGS = $logs;
     }
 }
-
-class_alias(TestLogProvider::class, 'EzSystems\Behat\Core\Log\TestLogProvider');

--- a/src/lib/Event/Events.php
+++ b/src/lib/Event/Events.php
@@ -30,5 +30,3 @@ class Events
 
     public const PUBLISH_LATER_TO_END = 'volume_testing.transition.publish_later_to_end';
 }
-
-class_alias(Events::class, 'EzSystems\Behat\Event\Events');

--- a/src/lib/Event/InitialEvent.php
+++ b/src/lib/Event/InitialEvent.php
@@ -40,5 +40,3 @@ class InitialEvent extends Event
         $this->mainLanguage = $mainLanguage;
     }
 }
-
-class_alias(InitialEvent::class, 'EzSystems\Behat\Event\InitialEvent');

--- a/src/lib/Event/TransitionEvent.php
+++ b/src/lib/Event/TransitionEvent.php
@@ -42,5 +42,3 @@ class TransitionEvent extends Event
         $this->mainLanguage = $mainLanguage;
     }
 }
-
-class_alias(TransitionEvent::class, 'EzSystems\Behat\Event\TransitionEvent');

--- a/src/lib/QueryType/FoldersUnderMediaQueryType.php
+++ b/src/lib/QueryType/FoldersUnderMediaQueryType.php
@@ -35,5 +35,3 @@ class FoldersUnderMediaQueryType implements QueryType
         return 'Folders under media';
     }
 }
-
-class_alias(FoldersUnderMediaQueryType::class, 'EzSystems\Behat\QueryType\FoldersUnderMediaQueryType');

--- a/src/lib/Subscriber/AbstractProcessStage.php
+++ b/src/lib/Subscriber/AbstractProcessStage.php
@@ -117,5 +117,3 @@ abstract class AbstractProcessStage
 
     abstract protected function doExecute(TransitionEvent $event): void;
 }
-
-class_alias(AbstractProcessStage::class, 'EzSystems\Behat\Subscriber\AbstractProcessStage');

--- a/src/lib/Subscriber/CreateContentDraft.php
+++ b/src/lib/Subscriber/CreateContentDraft.php
@@ -66,5 +66,3 @@ class CreateContentDraft extends AbstractProcessStage implements EventSubscriber
         $this->workflowFacade->transition($event->content, $transitionName, $this->randomDataGenerator->getRandomTextLine());
     }
 }
-
-class_alias(CreateContentDraft::class, 'EzSystems\Behat\Subscriber\CreateContentDraft');

--- a/src/lib/Subscriber/EditContent.php
+++ b/src/lib/Subscriber/EditContent.php
@@ -76,5 +76,3 @@ class EditContent extends AbstractProcessStage implements EventSubscriberInterfa
         $this->workflowFacade->transition($event->content, $transitionName, $this->randomDataGenerator->getRandomTextLine());
     }
 }
-
-class_alias(EditContent::class, 'EzSystems\Behat\Subscriber\EditContent');

--- a/src/lib/Subscriber/InitialStage.php
+++ b/src/lib/Subscriber/InitialStage.php
@@ -86,5 +86,3 @@ class InitialStage extends AbstractProcessStage implements EventSubscriberInterf
     {
     }
 }
-
-class_alias(InitialStage::class, 'EzSystems\Behat\Subscriber\InitialStage');

--- a/src/lib/Subscriber/PublishDraft.php
+++ b/src/lib/Subscriber/PublishDraft.php
@@ -64,5 +64,3 @@ class PublishDraft extends AbstractProcessStage implements EventSubscriberInterf
         $event->content = $this->contentService->publishVersion($event->content->versionInfo);
     }
 }
-
-class_alias(PublishDraft::class, 'EzSystems\Behat\Subscriber\PublishDraft');

--- a/src/lib/Subscriber/PublishInTheFuture.php
+++ b/src/lib/Subscriber/PublishInTheFuture.php
@@ -63,5 +63,3 @@ class PublishInTheFuture extends AbstractProcessStage implements EventSubscriber
         ];
     }
 }
-
-class_alias(PublishInTheFuture::class, 'EzSystems\Behat\Subscriber\PublishInTheFuture');

--- a/src/lib/Subscriber/Review.php
+++ b/src/lib/Subscriber/Review.php
@@ -77,5 +77,3 @@ class Review extends AbstractProcessStage implements EventSubscriberInterface
         $this->workflowFacade->transition($event->content, $transitionName, $this->randomDataGenerator->getRandomTextLine());
     }
 }
-
-class_alias(Review::class, 'EzSystems\Behat\Subscriber\Review');

--- a/tests/lib/Browser/Element/BaseTestCase.php
+++ b/tests/lib/Browser/Element/BaseTestCase.php
@@ -73,5 +73,3 @@ class BaseTestCase extends TestCase
         return new ElementCollection($locator, $elements);
     }
 }
-
-class_alias(BaseTestCase::class, 'EzSystems\Behat\Test\Browser\Element\BaseTestCase');

--- a/tests/lib/Browser/Element/Condition/ElementExistsConditionTest.php
+++ b/tests/lib/Browser/Element/Condition/ElementExistsConditionTest.php
@@ -43,5 +43,3 @@ class ElementExistsConditionTest extends BaseTestCase
         );
     }
 }
-
-class_alias(ElementExistsConditionTest::class, 'EzSystems\Behat\Test\Browser\Element\Condition\ElementExistsConditionTest');

--- a/tests/lib/Browser/Element/Condition/ElementNotExistsConditionTest.php
+++ b/tests/lib/Browser/Element/Condition/ElementNotExistsConditionTest.php
@@ -47,5 +47,3 @@ class ElementNotExistsConditionTest extends BaseTestCase
         );
     }
 }
-
-class_alias(ElementNotExistsConditionTest::class, 'EzSystems\Behat\Test\Browser\Element\Condition\ElementNotExistsConditionTest');

--- a/tests/lib/Browser/Element/Condition/ElementTransitionHasEndedConditionTest.php
+++ b/tests/lib/Browser/Element/Condition/ElementTransitionHasEndedConditionTest.php
@@ -76,5 +76,3 @@ class ElementTransitionHasEndedConditionTest extends BaseTestCase
         return $childElement;
     }
 }
-
-class_alias(ElementTransitionHasEndedConditionTest::class, 'EzSystems\Behat\Test\Browser\Element\Condition\ElementTransitionHasEndedConditionTest');

--- a/tests/lib/Browser/Element/Condition/ElementsCountConditionTest.php
+++ b/tests/lib/Browser/Element/Condition/ElementsCountConditionTest.php
@@ -45,5 +45,3 @@ class ElementsCountConditionTest extends BaseTestCase
         );
     }
 }
-
-class_alias(ElementsCountConditionTest::class, 'EzSystems\Behat\Test\Browser\Element\Condition\ElementsCountConditionTest');

--- a/tests/lib/Browser/Element/Condition/ElementsCountGreaterThanConditionTest.php
+++ b/tests/lib/Browser/Element/Condition/ElementsCountGreaterThanConditionTest.php
@@ -45,5 +45,3 @@ class ElementsCountGreaterThanConditionTest extends BaseTestCase
         );
     }
 }
-
-class_alias(ElementsCountGreaterThanConditionTest::class, 'EzSystems\Behat\Test\Browser\Element\Condition\ElementsCountGreaterThanConditionTest');

--- a/tests/lib/Browser/Element/Criterion/ChildElementTextCriterionTest.php
+++ b/tests/lib/Browser/Element/Criterion/ChildElementTextCriterionTest.php
@@ -69,5 +69,3 @@ class ChildElementTextCriterionTest extends BaseTestCase
         );
     }
 }
-
-class_alias(ChildElementTextCriterionTest::class, 'EzSystems\Behat\Test\Browser\Element\Criterion\ChildElementTextCriterionTest');

--- a/tests/lib/Browser/Element/Criterion/ElementAttributeCriterionTest.php
+++ b/tests/lib/Browser/Element/Criterion/ElementAttributeCriterionTest.php
@@ -66,5 +66,3 @@ class ElementAttributeCriterionTest extends BaseTestCase
         return $element;
     }
 }
-
-class_alias(ElementAttributeCriterionTest::class, 'EzSystems\Behat\Test\Browser\Element\Criterion\ElementAttributeCriterionTest');

--- a/tests/lib/Browser/Element/Criterion/ElementTextCriterionTest.php
+++ b/tests/lib/Browser/Element/Criterion/ElementTextCriterionTest.php
@@ -56,5 +56,3 @@ class ElementTextCriterionTest extends BaseTestCase
         );
     }
 }
-
-class_alias(ElementTextCriterionTest::class, 'EzSystems\Behat\Test\Browser\Element\Criterion\ElementTextCriterionTest');

--- a/tests/lib/Browser/Element/Criterion/ElementTextFragmentCriterionTest.php
+++ b/tests/lib/Browser/Element/Criterion/ElementTextFragmentCriterionTest.php
@@ -56,5 +56,3 @@ class ElementTextFragmentCriterionTest extends BaseTestCase
         );
     }
 }
-
-class_alias(ElementTextFragmentCriterionTest::class, 'EzSystems\Behat\Test\Browser\Element\Criterion\ElementTextFragmentCriterionTest');

--- a/tests/lib/Browser/Element/Criterion/LogicalOrCriterionTest.php
+++ b/tests/lib/Browser/Element/Criterion/LogicalOrCriterionTest.php
@@ -47,5 +47,3 @@ Could not find element named: 'Test2'. Found names: Test3 instead. CSS locator '
         );
     }
 }
-
-class_alias(LogicalOrCriterionTest::class, 'EzSystems\Behat\Test\Browser\Element\Criterion\LogicalOrCriterionTest');

--- a/tests/lib/Browser/Element/Debug/Assert/Interactive/CollectionAssertTest.php
+++ b/tests/lib/Browser/Element/Debug/Assert/Interactive/CollectionAssertTest.php
@@ -22,5 +22,3 @@ class CollectionAssertTest extends TestCase
         Assert::assertInstanceOf(CollectionAssert::class, $collectionAssert);
     }
 }
-
-class_alias(CollectionAssertTest::class, 'EzSystems\Behat\Test\Browser\Element\Debug\Assert\Interactive\CollectionAssertTest');

--- a/tests/lib/Browser/Element/Debug/Assert/Interactive/ElementAssertTest.php
+++ b/tests/lib/Browser/Element/Debug/Assert/Interactive/ElementAssertTest.php
@@ -22,5 +22,3 @@ class ElementAssertTest extends TestCase
         Assert::assertInstanceOf(ElementAssert::class, $collectionAssert);
     }
 }
-
-class_alias(ElementAssertTest::class, 'EzSystems\Behat\Test\Browser\Element\Debug\Assert\Interactive\ElementAssertTest');

--- a/tests/lib/Browser/Element/Debug/HighlightingElementTest.php
+++ b/tests/lib/Browser/Element/Debug/HighlightingElementTest.php
@@ -23,5 +23,3 @@ class HighlightingElementTest extends TestCase
         Assert::assertInstanceOf(Element::class, $element);
     }
 }
-
-class_alias(HighlightingElementTest::class, 'EzSystems\Behat\Test\Browser\Element\Debug\HighlightingElementTest');

--- a/tests/lib/Browser/Element/Debug/InteractiveElementTest.php
+++ b/tests/lib/Browser/Element/Debug/InteractiveElementTest.php
@@ -22,5 +22,3 @@ class InteractiveElementTest extends TestCase
         Assert::assertInstanceOf(Element::class, $element);
     }
 }
-
-class_alias(InteractiveElementTest::class, 'EzSystems\Behat\Test\Browser\Element\Debug\InteractiveElementTest');

--- a/tests/lib/Browser/Element/ElementCollectionTest.php
+++ b/tests/lib/Browser/Element/ElementCollectionTest.php
@@ -197,5 +197,3 @@ class ElementCollectionTest extends BaseTestCase
         );
     }
 }
-
-class_alias(ElementCollectionTest::class, 'EzSystems\Behat\Test\Browser\Element\ElementCollectionTest');

--- a/tests/lib/Browser/Element/ElementTest.php
+++ b/tests/lib/Browser/Element/ElementTest.php
@@ -183,5 +183,3 @@ class ElementTest extends BaseTestCase
         return new Element(new ElementFactory(), $this->irrelevantLocator, $nodeElement);
     }
 }
-
-class_alias(ElementTest::class, 'EzSystems\Behat\Test\Browser\Element\ElementTest');

--- a/tests/lib/Browser/Filter/BrowserLogFilterTest.php
+++ b/tests/lib/Browser/Filter/BrowserLogFilterTest.php
@@ -39,5 +39,3 @@ class BrowserLogFilterTest extends TestCase
         Assert::assertEquals(['Real JS Error', 'Another real JS error'], $actualResult);
     }
 }
-
-class_alias(BrowserLogFilterTest::class, 'EzSystems\Behat\Test\Browser\Filter\BrowserLogFilterTest');

--- a/tests/lib/Core/Behat/ArgumentParserTest.php
+++ b/tests/lib/Core/Behat/ArgumentParserTest.php
@@ -57,5 +57,3 @@ class ArgumentParserTest extends TestCase
         ];
     }
 }
-
-class_alias(ArgumentParserTest::class, 'EzSystems\Behat\Test\Core\Behat\ArgumentParserTest');

--- a/tests/lib/Core/Behat/ExtendedTableNodeTest.php
+++ b/tests/lib/Core/Behat/ExtendedTableNodeTest.php
@@ -88,5 +88,3 @@ class ExtendedTableNodeTest extends TestCase
             ['Value21', 'Value23'], ], $afterTable->getTable());
     }
 }
-
-class_alias(ExtendedTableNodeTest::class, 'EzSystems\Behat\Test\Core\Behat\ExtendedTableNodeTest');

--- a/tests/lib/Core/Configuration/ConfigurationEditorTest.php
+++ b/tests/lib/Core/Configuration/ConfigurationEditorTest.php
@@ -295,5 +295,3 @@ class ConfigurationEditorTest extends TestCase
         Assert::assertEquals(['baseKey' => ['initialValue1' => 'nestedValue1', 'initialValue2', 'copiedKey' => 'nestedValue1']], $changedConfig);
     }
 }
-
-class_alias(ConfigurationEditorTest::class, 'EzSystems\Behat\Test\Core\Configuration\ConfigurationEditorTest');

--- a/tests/lib/Core/Configuration/LocationAwareConfigurationEditorTest.php
+++ b/tests/lib/Core/Configuration/LocationAwareConfigurationEditorTest.php
@@ -90,5 +90,3 @@ class LocationAwareConfigurationEditorTest extends TestCase
         Assert::assertEquals(['testKey' => [2, 5]], $config);
     }
 }
-
-class_alias(LocationAwareConfigurationEditorTest::class, 'EzSystems\Behat\Test\Core\Configuration\LocationAwareConfigurationEditorTest');

--- a/tests/lib/Core/Log/LogFileReaderTest.php
+++ b/tests/lib/Core/Log/LogFileReaderTest.php
@@ -80,5 +80,3 @@ EOD
         Assert::assertEquals([2, 3, 4, 5, 6], $logEntries);
     }
 }
-
-class_alias(LogFileReaderTest::class, 'EzSystems\Behat\Test\Core\Log\LogFileReaderTest');


### PR DESCRIPTION
| :ticket: Issue | IBX-8139 |
|----------------|-----------|

#### Description:

Dropped `class_alias` BC layer statements from all classes using https://github.com/ibexa/rector/pull/2

CI is failing for Authorization Behat scenario which is expected at this point.

#### For QA:

No QA needed

#### Documentation:

Document that our BC layer has been dropped
