### PR TITLE
IBX-8136: Drop conflicting behat/mink-goutte-driver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
         "behat/behat": "^3.13",
-        "behat/mink-goutte-driver": "^1.2",
         "behat/mink-selenium2-driver": "^1.4",
         "bex/behat-screenshot": "^2.1",
         "dmore/behat-chrome-extension": "^1.3",

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "dmore/chrome-mink-driver": "^2.7",
         "ezsystems/behat-screenshot-image-driver-cloudinary": "^1.1@dev",
         "ibexa/core": "~5.0.0@dev",
+        "fabpot/goutte": "^4.0",
         "friends-of-behat/mink": "^1.8",
         "friends-of-behat/mink-browserkit-driver": "^1.4",
         "friends-of-behat/mink-extension": "^2.4",


### PR DESCRIPTION
| :ticket: Issue | IBX-8136 |
|----------------|-----------|


#### Related PRs: 
- https://github.com/ibexa/personalization/pull/351


#### Description:
For starters trying to just remove the pacakge.

Note: `behat/mink-browserkit-driver` is a replacement for `friends-of-behat/mink-browserkit-driver` (which conflict themself), not `behat/mink-goutte-driver`.

Status: These packages are seriously outdated. There might not be a simple replacement. Smells like bigger refactoring.

#### For QA:
(https://github.com/FriendsOfPHP/Goutte/releases)

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
