### PR TITLE
[Behat] IBX-8636: Added new tag to admin-ui job

### DIFF
--- a/.github/workflows/browser-tests.yaml
+++ b/.github/workflows/browser-tests.yaml
@@ -13,11 +13,10 @@ jobs:
         uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
         with:
             project-edition: 'oss'
-            test-suite:  '--profile=browser --suite=admin-ui-full --tags=~@broken'
             test-setup-phase-1: '--profile=regression --suite=setup-oss --mode=standard'
+            test-suite: "--mode=standard --profile=browser --suite=admin-ui-full --tags='~@broken&&~@IbexaDXP'"
             multirepository: true
             timeout: 40
-            job-count: 2
         secrets:
             SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     examples:


### PR DESCRIPTION
| :ticket: Issue | IBX-8636 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
This PR adds new tag to admin ui job to exclude user profile test. In ibexa/behat repo we run admin-ui job on oss edition, Editor CT is enabled from headless edition, what causes a fail https://github.com/ibexa/behat/actions/runs/10279575369/job/28445202414
To use condition like `--tags='~@broken&&~@IbexaDXP'` we must use `--mode=standard` which consequently makes it impossible to use job-count (only in this job).

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
