### PR TITLE
Fix for minkphpwebdriver 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "ezsystems/behatbundle": "*"
     },
     "require": {
-        "php": "^8.1",
+        "php": "^7.4 || ^8.0",
         "ext-json": "*",
         "behat/behat": "^3.13",
         "behat/mink-goutte-driver": "^1.2",
@@ -29,13 +29,13 @@
         "symfony/console": "^5.0",
         "symfony/dependency-injection": "^5.0",
         "symfony/lock": "^5.0",
-        "symfony/stopwatch": "^5.2",
+        "symfony/stopwatch": "^5.2"
         "symfony/http-kernel": "^5.0",
         "symfony/process": "^5.4",
         "symfony/property-access": "^5.0",
         "symfony/yaml": "^5.0",
         "psy/psysh": "^0.10.8",
-        "oleg-andreyev/mink-phpwebdriver": "^1.4",
+        "oleg-andreyev/mink-phpwebdriver": "1.3",
         "oleg-andreyev/mink-phpwebdriver-extension": "^1.0",
         "symfony/form": "^5.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "symfony/console": "^5.0",
         "symfony/dependency-injection": "^5.0",
         "symfony/lock": "^5.0",
-        "symfony/stopwatch": "^5.2"
+        "symfony/stopwatch": "^5.2",
         "symfony/http-kernel": "^5.0",
         "symfony/process": "^5.4",
         "symfony/property-access": "^5.0",

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "symfony/property-access": "^5.0",
         "symfony/yaml": "^5.0",
         "psy/psysh": "^0.10.8",
-        "oleg-andreyev/mink-phpwebdriver": "^1.2",
+        "oleg-andreyev/mink-phpwebdriver": "^1.4",
         "oleg-andreyev/mink-phpwebdriver-extension": "^1.0",
         "symfony/form": "^5.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "ezsystems/behatbundle": "*"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "behat/behat": "^3.13",
         "behat/mink-goutte-driver": "^1.2",

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "symfony/property-access": "^5.0",
         "symfony/yaml": "^5.0",
         "psy/psysh": "^0.10.8",
-        "oleg-andreyev/mink-phpwebdriver": "<1.4.0",
+        "oleg-andreyev/mink-phpwebdriver": "<1.3.3",
         "oleg-andreyev/mink-phpwebdriver-extension": "^1.0",
         "symfony/form": "^5.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "symfony/property-access": "^5.0",
         "symfony/yaml": "^5.0",
         "psy/psysh": "^0.10.8",
-        "oleg-andreyev/mink-phpwebdriver": "1.3",
+        "oleg-andreyev/mink-phpwebdriver": "<1.4.0",
         "oleg-andreyev/mink-phpwebdriver-extension": "^1.0",
         "symfony/form": "^5.4"
     },


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

#### Description:
This PR fixes CI failures such like https://github.com/ibexa/product-catalog-date-time-attribute/actions/runs/11832540541. It seems that 1.3.2 is the maximum version on which our current tests are green.
To be noted - this should be a **temporary** fix, and our friend-of-behat dependency should be resolved.

CI build: https://github.com/ibexa/commerce/pull/1115

![1718618887011425](https://github.com/user-attachments/assets/f0fbcb9c-fe4c-458a-a6d8-76ed829ceb03)





