### PR TITLE
IBX-8470: Upgraded codebase to Symfony 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For more information about BehatBundle, see:
 
 Copyright (C) 1999-2024 Ibexa AS (formerly eZ Systems AS). All rights reserved.
 
-## LICENSE
+## LICENSE`
 
 This source code is available separately under the following licenses:
 

--- a/behat_ibexa_oss.yaml
+++ b/behat_ibexa_oss.yaml
@@ -53,16 +53,6 @@ default:
 
         Liuggio\Fastest\Behat\ListFeaturesExtension\Extension: ~
 
-        Bex\Behat\ScreenshotExtension:
-            active_image_drivers: cloudinary
-            image_drivers:
-                cloudinary:
-                    screenshot_directory: /tmp/behat-screenshot/
-                    cloud_name: ezplatformtravis
-                    preset: ezplatform
-                    mode: normal
-                    limit: 10
-
     suites: ~
 
 regression:
@@ -90,7 +80,7 @@ regression:
               - '%paths.base%/vendor/ibexa/user/features/browser'
             filters:
                 tags: "~@broken&&@IbexaOSS"
-            contexts: 
+            contexts:
                 - Behat\MinkExtension\Context\MinkContext
                 - Ibexa\Behat\API\Context\ContentContext
                 - Ibexa\Behat\API\Context\ContentTypeContext

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "dmore/chrome-mink-driver": "^2.7",
         "ezsystems/behat-screenshot-image-driver-cloudinary": "^1.1@dev",
         "ibexa/core": "~5.0.0@dev",
-        "behat/mink": "^1.11",
+        "friends-of-behat/mink": "^1.11",
         "friends-of-behat/mink-browserkit-driver": "^1.4",
         "friends-of-behat/mink-extension": "^2.4",
         "friends-of-behat/symfony-extension": "^2.1",
@@ -42,7 +42,6 @@
     "require-dev": {
         "ibexa/code-style": "~2.0.0",
         "friendsofphp/php-cs-fixer": "^3.0",
-        "ibexa/ci-scripts": "^0.2@dev",
         "ibexa/doctrine-schema": "~5.0.0@dev",
         "mikey179/vfsstream": "^1.6",
         "phpstan/phpstan": "^1.10",

--- a/composer.json
+++ b/composer.json
@@ -25,19 +25,19 @@
         "liuggio/fastest": "^1.11",
         "php-http/client-common": "^2.1",
         "phpunit/phpunit": "^8.5 || ^9.0 || ^10.0",
-        "symfony/config": "^5.0",
-        "symfony/console": "^5.0",
-        "symfony/dependency-injection": "^5.0",
-        "symfony/lock": "^5.0",
-        "symfony/stopwatch": "^5.2",
-        "symfony/http-kernel": "^5.0",
-        "symfony/process": "^5.4",
-        "symfony/property-access": "^5.0",
-        "symfony/yaml": "^5.0",
+        "symfony/config": "^6.4",
+        "symfony/console": "^6.4",
+        "symfony/dependency-injection": "^6.4",
+        "symfony/lock": "^6.4",
+        "symfony/stopwatch": "^6.4",
+        "symfony/http-kernel": "^6.4",
+        "symfony/process": "^6.4",
+        "symfony/property-access": "^6.4",
+        "symfony/yaml": "^6.4",
         "psy/psysh": "^0.10.8",
         "oleg-andreyev/mink-phpwebdriver": "^1.2.1",
         "oleg-andreyev/mink-phpwebdriver-extension": "^1.0",
-        "symfony/form": "^5.4"
+        "symfony/form": "^6.4"
     },
     "require-dev": {
         "ibexa/code-style": "~2.0.0",
@@ -48,7 +48,7 @@
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-phpunit": "^1.3",
         "phpstan/phpstan-symfony": "^1.3",
-        "symfony/phpunit-bridge": "^6.3"
+        "symfony/phpunit-bridge": "^6.4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "ezsystems/behatbundle": "*"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": ">=8.3",
         "ext-json": "*",
         "behat/behat": "^3.13",
         "behat/mink-goutte-driver": "^1.2",

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,6 @@
     },
     "require-dev": {
         "ibexa/code-style": "~2.0.0",
-        "friendsofphp/php-cs-fixer": "^3.0",
         "ibexa/doctrine-schema": "~5.0.0@dev",
         "mikey179/vfsstream": "^1.6",
         "phpstan/phpstan": "^1.10",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
         "php": ">=8.3",
         "ext-json": "*",
         "behat/behat": "^3.13",
-        "behat/mink-goutte-driver": "^1.2",
         "behat/mink-selenium2-driver": "^1.4",
         "bex/behat-screenshot": "^2.1",
         "dmore/behat-chrome-extension": "^1.3",

--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,8 @@
         "symfony/process": "^6.4",
         "symfony/property-access": "^6.4",
         "symfony/yaml": "^6.4",
-        "psy/psysh": "^0.10.8",
-        "oleg-andreyev/mink-phpwebdriver": "^1.2.1",
+        "psy/psysh": "^0.12.4",
+        "oleg-andreyev/mink-phpwebdriver": "<1.3.3",
         "oleg-andreyev/mink-phpwebdriver-extension": "^1.0",
         "symfony/form": "^6.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,6 @@
         "ext-json": "*",
         "behat/behat": "^3.13",
         "behat/mink-selenium2-driver": "^1.4",
-        "bex/behat-screenshot": "^2.1",
         "dmore/behat-chrome-extension": "^1.3",
         "dmore/chrome-mink-driver": "^2.7",
         "ezsystems/behat-screenshot-image-driver-cloudinary": "^1.1@dev",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -126,6 +126,11 @@ parameters:
 			path: src/bundle/Initializer/BehatSiteAccessInitializer.php
 
 		-
+			message: "#^Call to an undefined method Behat\\\\Gherkin\\\\Node\\\\ScenarioLikeInterface\\:\\:hasTag\\(\\)\\.$#"
+			count: 1
+			path: src/bundle/Subscriber/StartScenarioSubscriber.php
+
+		-
 			message: "#^Cannot call method isStarted\\(\\) on object\\|null\\.$#"
 			count: 1
 			path: src/bundle/Subscriber/StartScenarioSubscriber.php
@@ -901,12 +906,7 @@ parameters:
 			path: src/lib/API/Facade/RoleFacade.php
 
 		-
-			message: "#^Access to an undefined property Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\ValueObject\\:\\:\\$contentInfo\\.$#"
-			count: 2
-			path: src/lib/API/Facade/SearchFacade.php
-
-		-
-			message: "#^Argument of an invalid type array\\<int, int\\|string\\>\\|int\\|string supplied for foreach, only iterables are supported\\.$#"
+			message: "#^Argument of an invalid type array\\<int, int\\>\\|int supplied for foreach, only iterables are supported\\.$#"
 			count: 1
 			path: src/lib/API/Facade/SearchFacade.php
 
@@ -921,17 +921,12 @@ parameters:
 			path: src/lib/API/Facade/SearchFacade.php
 
 		-
-			message: "#^Parameter \\#1 \\$location of method Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\URLAliasService\\:\\:reverseLookup\\(\\) expects Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\ValueObject given\\.$#"
-			count: 1
-			path: src/lib/API/Facade/SearchFacade.php
-
-		-
 			message: "#^Parameter \\#1 \\$min \\(0\\) of function random_int expects lower number than parameter \\#2 \\$max \\(int\\<\\-1, max\\>\\)\\.$#"
 			count: 1
 			path: src/lib/API/Facade/SearchFacade.php
 
 		-
-			message: "#^Possibly invalid array key type array\\<int, int\\|string\\>\\|int\\|string\\.$#"
+			message: "#^Possibly invalid array key type array\\<int, int\\>\\|int\\.$#"
 			count: 1
 			path: src/lib/API/Facade/SearchFacade.php
 
@@ -939,11 +934,6 @@ parameters:
 			message: "#^Method Ibexa\\\\Behat\\\\API\\\\Facade\\\\TrashFacade\\:\\:trash\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/lib/API/Facade/TrashFacade.php
-
-		-
-			message: "#^Access to an undefined property Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\ValueObject\\:\\:\\$contentInfo\\.$#"
-			count: 1
-			path: src/lib/API/Facade/UserFacade.php
 
 		-
 			message: "#^Method Ibexa\\\\Behat\\\\API\\\\Facade\\\\UserFacade\\:\\:assignUserGroupToRole\\(\\) has no return type specified\\.$#"
@@ -2161,12 +2151,12 @@ parameters:
 			path: src/lib/Core/Log/Failure/AnalysisResult.php
 
 		-
-			message: "#^Cannot call method getMessage\\(\\) on Exception\\|null\\.$#"
+			message: "#^Cannot call method getMessage\\(\\) on Throwable\\|null\\.$#"
 			count: 1
 			path: src/lib/Core/Log/Failure/TestFailureData.php
 
 		-
-			message: "#^Cannot call method getTraceAsString\\(\\) on Exception\\|null\\.$#"
+			message: "#^Cannot call method getTraceAsString\\(\\) on Throwable\\|null\\.$#"
 			count: 1
 			path: src/lib/Core/Log/Failure/TestFailureData.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,11 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Behat\\\\Command\\\\CreateExampleDataCommand\\:\\:configure\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/bundle/Command/CreateExampleDataCommand.php
-
-		-
 			message: "#^Method Ibexa\\\\Bundle\\\\Behat\\\\Command\\\\CreateExampleDataManagerCommand\\:\\:createProcesses\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/bundle/Command/CreateExampleDataManagerCommand.php
@@ -39,16 +34,6 @@ parameters:
 			message: "#^Property Ibexa\\\\Bundle\\\\Behat\\\\Command\\\\CreateExampleDataManagerCommand\\:\\:\\$processes type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/bundle/Command/CreateExampleDataManagerCommand.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Behat\\\\Command\\\\CreateLanguageCommand\\:\\:configure\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/bundle/Command/CreateLanguageCommand.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Behat\\\\Command\\\\TestSiteaccessCommand\\:\\:configure\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/bundle/Command/TestSiteaccessCommand.php
 
 		-
 			message: "#^Method Ibexa\\\\Bundle\\\\Behat\\\\Controller\\\\ExceptionController\\:\\:throwRepositoryUnauthorizedAction\\(\\) has no return type specified\\.$#"
@@ -91,32 +76,7 @@ parameters:
 			path: src/bundle/Controller/UnauthenticatedRedirectController.php
 
 		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Behat\\\\DependencyInjection\\\\Compiler\\\\ElementFactoryCompilerPass\\:\\:process\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/bundle/DependencyInjection/Compiler/ElementFactoryCompilerPass.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Behat\\\\DependencyInjection\\\\Compiler\\\\FieldTypeDataProviderPass\\:\\:process\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/bundle/DependencyInjection/Compiler/FieldTypeDataProviderPass.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Behat\\\\DependencyInjection\\\\Compiler\\\\LimitationParserPass\\:\\:process\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/bundle/DependencyInjection/Compiler/LimitationParserPass.php
-
-		-
 			message: "#^Method Ibexa\\\\Bundle\\\\Behat\\\\DependencyInjection\\\\IbexaBehatExtension\\:\\:load\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/bundle/DependencyInjection/IbexaBehatExtension.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Behat\\\\DependencyInjection\\\\IbexaBehatExtension\\:\\:prepend\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/bundle/DependencyInjection/IbexaBehatExtension.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Behat\\\\DependencyInjection\\\\IbexaBehatExtension\\:\\:process\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/bundle/DependencyInjection/IbexaBehatExtension.php
 
@@ -124,61 +84,6 @@ parameters:
 			message: "#^Method Ibexa\\\\Bundle\\\\Behat\\\\DependencyInjection\\\\IbexaBehatExtension\\:\\:shouldLoadDxpServices\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/bundle/DependencyInjection/IbexaBehatExtension.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Behat\\\\Form\\\\RetryChoiceListFactory\\:\\:createListFromChoices\\(\\) has parameter \\$choices with no value type specified in iterable type iterable\\.$#"
-			count: 1
-			path: src/bundle/Form/RetryChoiceListFactory.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Behat\\\\Form\\\\RetryChoiceListFactory\\:\\:createListFromChoices\\(\\) has parameter \\$value with no type specified\\.$#"
-			count: 1
-			path: src/bundle/Form/RetryChoiceListFactory.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Behat\\\\Form\\\\RetryChoiceListFactory\\:\\:createListFromLoader\\(\\) has parameter \\$value with no type specified\\.$#"
-			count: 1
-			path: src/bundle/Form/RetryChoiceListFactory.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Behat\\\\Form\\\\RetryChoiceListFactory\\:\\:createView\\(\\) has parameter \\$attr with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/bundle/Form/RetryChoiceListFactory.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Behat\\\\Form\\\\RetryChoiceListFactory\\:\\:createView\\(\\) has parameter \\$groupBy with no type specified\\.$#"
-			count: 1
-			path: src/bundle/Form/RetryChoiceListFactory.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Behat\\\\Form\\\\RetryChoiceListFactory\\:\\:createView\\(\\) has parameter \\$index with no type specified\\.$#"
-			count: 1
-			path: src/bundle/Form/RetryChoiceListFactory.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Behat\\\\Form\\\\RetryChoiceListFactory\\:\\:createView\\(\\) has parameter \\$preferredChoices with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/bundle/Form/RetryChoiceListFactory.php
-
-		-
-			message: "#^Method Symfony\\\\Component\\\\Form\\\\ChoiceList\\\\Factory\\\\ChoiceListFactoryInterface\\:\\:createListFromChoices\\(\\) invoked with 3 parameters, 1\\-2 required\\.$#"
-			count: 1
-			path: src/bundle/Form/RetryChoiceListFactory.php
-
-		-
-			message: "#^Method Symfony\\\\Component\\\\Form\\\\ChoiceList\\\\Factory\\\\ChoiceListFactoryInterface\\:\\:createListFromLoader\\(\\) invoked with 3 parameters, 1\\-2 required\\.$#"
-			count: 1
-			path: src/bundle/Form/RetryChoiceListFactory.php
-
-		-
-			message: "#^Method Symfony\\\\Component\\\\Form\\\\ChoiceList\\\\Factory\\\\ChoiceListFactoryInterface\\:\\:createView\\(\\) invoked with 7 parameters, 1\\-6 required\\.$#"
-			count: 1
-			path: src/bundle/Form/RetryChoiceListFactory.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Behat\\\\IbexaBehatBundle\\:\\:build\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/bundle/IbexaBehatBundle.php
 
 		-
 			message: "#^Method Ibexa\\\\Bundle\\\\Behat\\\\IbexaExtension\\:\\:configure\\(\\) has no return type specified\\.$#"
@@ -197,11 +102,6 @@ parameters:
 
 		-
 			message: "#^Method Ibexa\\\\Bundle\\\\Behat\\\\IbexaExtension\\:\\:loadStartScenarioSubscriber\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/bundle/IbexaExtension.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Behat\\\\IbexaExtension\\:\\:process\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/bundle/IbexaExtension.php
 
@@ -2246,57 +2146,7 @@ parameters:
 			path: src/lib/Core/Context/TimeContext.php
 
 		-
-			message: "#^Method Ibexa\\\\Behat\\\\Core\\\\Debug\\\\Command\\\\GoBackCommand\\:\\:configure\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Core/Debug/Command/GoBackCommand.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Core\\\\Debug\\\\Command\\\\RefreshPageCommand\\:\\:configure\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Core/Debug/Command/RefreshPageCommand.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Core\\\\Debug\\\\Command\\\\ShowHTMLCommand\\:\\:configure\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Core/Debug/Command/ShowHTMLCommand.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Core\\\\Debug\\\\Command\\\\ShowURLCommand\\:\\:configure\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Core/Debug/Command/ShowURLCommand.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Core\\\\Debug\\\\Command\\\\TakeScreenshotCommand\\:\\:configure\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Core/Debug/Command/TakeScreenshotCommand.php
-
-		-
 			message: "#^Cannot call method getName\\(\\) on ReflectionType\\|null\\.$#"
-			count: 1
-			path: src/lib/Core/Debug/Matcher/ObjectFunctionCallChainMatcher.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Core\\\\Debug\\\\Matcher\\\\ObjectFunctionCallChainMatcher\\:\\:getFunctionName\\(\\) has parameter \\$tokenGroup with no type specified\\.$#"
-			count: 1
-			path: src/lib/Core/Debug/Matcher/ObjectFunctionCallChainMatcher.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Core\\\\Debug\\\\Matcher\\\\ObjectFunctionCallChainMatcher\\:\\:getMatches\\(\\) has parameter \\$info with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Core/Debug/Matcher/ObjectFunctionCallChainMatcher.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Core\\\\Debug\\\\Matcher\\\\ObjectFunctionCallChainMatcher\\:\\:getMatches\\(\\) has parameter \\$tokens with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Core/Debug/Matcher/ObjectFunctionCallChainMatcher.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Core\\\\Debug\\\\Matcher\\\\ObjectFunctionCallChainMatcher\\:\\:getMatches\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Core/Debug/Matcher/ObjectFunctionCallChainMatcher.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Core\\\\Debug\\\\Matcher\\\\ObjectFunctionCallChainMatcher\\:\\:getObjectClass\\(\\) has parameter \\$tokenGroup with no type specified\\.$#"
 			count: 1
 			path: src/lib/Core/Debug/Matcher/ObjectFunctionCallChainMatcher.php
 
@@ -2304,51 +2154,6 @@ parameters:
 			message: "#^Method Ibexa\\\\Behat\\\\Core\\\\Debug\\\\Matcher\\\\ObjectFunctionCallChainMatcher\\:\\:getObjectClass\\(\\) should return string but returns class\\-string\\|false\\.$#"
 			count: 1
 			path: src/lib/Core/Debug/Matcher/ObjectFunctionCallChainMatcher.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Core\\\\Debug\\\\Matcher\\\\ObjectFunctionCallChainMatcher\\:\\:getTokenName\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Core/Debug/Matcher/ObjectFunctionCallChainMatcher.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Core\\\\Debug\\\\Matcher\\\\ObjectFunctionCallChainMatcher\\:\\:getTokenName\\(\\) has parameter \\$token with no type specified\\.$#"
-			count: 1
-			path: src/lib/Core/Debug/Matcher/ObjectFunctionCallChainMatcher.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Core\\\\Debug\\\\Matcher\\\\ObjectFunctionCallChainMatcher\\:\\:isFunctionCall\\(\\) has parameter \\$tokenGroup with no type specified\\.$#"
-			count: 1
-			path: src/lib/Core/Debug/Matcher/ObjectFunctionCallChainMatcher.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Core\\\\Debug\\\\Matcher\\\\ObjectFunctionCallChainMatcher\\:\\:isObjectCall\\(\\) has parameter \\$tokenGroup with no type specified\\.$#"
-			count: 1
-			path: src/lib/Core/Debug/Matcher/ObjectFunctionCallChainMatcher.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Core\\\\Debug\\\\Matcher\\\\ThisObjectMethodsMatcher\\:\\:getMatches\\(\\) has parameter \\$info with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Core/Debug/Matcher/ThisObjectMethodsMatcher.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Core\\\\Debug\\\\Matcher\\\\ThisObjectMethodsMatcher\\:\\:getMatches\\(\\) has parameter \\$tokens with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Core/Debug/Matcher/ThisObjectMethodsMatcher.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Core\\\\Debug\\\\Matcher\\\\ThisObjectMethodsMatcher\\:\\:getMatches\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Core/Debug/Matcher/ThisObjectMethodsMatcher.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Core\\\\Debug\\\\Shell\\\\Shell\\:\\:displayExceptionMessage\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Core/Debug/Shell/Shell.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Core\\\\Debug\\\\Shell\\\\Shell\\:\\:getDefaultMatchers\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Core/Debug/Shell/Shell.php
 
 		-
 			message: "#^Method Ibexa\\\\Behat\\\\Core\\\\Log\\\\Failure\\\\AnalysisResult\\:\\:getJiraReference\\(\\) should return string but returns string\\|null\\.$#"
@@ -2734,21 +2539,6 @@ parameters:
 			message: "#^Method Ibexa\\\\Tests\\\\Behat\\\\Browser\\\\Locator\\\\Validator\\\\CssLocatorValidatorTest\\:\\:provideValidSelectors\\(\\) return type has no value type specified in iterable type iterable\\.$#"
 			count: 1
 			path: tests/Browser/Locator/Validator/CssLocatorValidatorTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Behat\\\\Form\\\\Stub\\\\UnstableChoiceListFactory\\:\\:createListFromChoices\\(\\) has parameter \\$choices with no value type specified in iterable type iterable\\.$#"
-			count: 1
-			path: tests/bundle/Form/Stub/UnstableChoiceListFactory.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Behat\\\\Form\\\\Stub\\\\UnstableChoiceListFactory\\:\\:createView\\(\\) has parameter \\$attr with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/bundle/Form/Stub/UnstableChoiceListFactory.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Behat\\\\Form\\\\Stub\\\\UnstableChoiceListFactory\\:\\:createView\\(\\) has parameter \\$preferredChoices with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/bundle/Form/Stub/UnstableChoiceListFactory.php
 
 		-
 			message: "#^Method Ibexa\\\\Tests\\\\Behat\\\\Browser\\\\Element\\\\BaseTestCase\\:\\:createCollection\\(\\) has parameter \\$elementTexts with no type specified\\.$#"

--- a/src/bundle/Form/RetryChoiceListFactory.php
+++ b/src/bundle/Form/RetryChoiceListFactory.php
@@ -25,48 +25,64 @@ final class RetryChoiceListFactory implements ChoiceListFactoryInterface
         $this->choiceListFactory = $choiceListFactory;
     }
 
-    /** {@inheritDoc} */
-    public function createListFromChoices(iterable $choices, $value = null): ChoiceListInterface
-    {
-        $filter = \func_num_args() > 2 ? func_get_arg(2) : null;
-
+    /**
+     * @param iterable<string, mixed> $choices
+     *
+     * @throws \ErrorException
+     */
+    public function createListFromChoices(
+        iterable $choices,
+        ?callable $value = null,
+        ?callable $filter = null
+    ): ChoiceListInterface {
         return $this->executeWithRetry(function () use ($choices, $value, $filter) {
             return $this->choiceListFactory->createListFromChoices($choices, $value, $filter);
         });
     }
 
-    /** {@inheritDoc} */
-    public function createListFromLoader(ChoiceLoaderInterface $loader, $value = null): ChoiceListInterface
-    {
-        $filter = \func_num_args() > 2 ? func_get_arg(2) : null;
-
+    /**
+     * @throws \ErrorException
+     */
+    public function createListFromLoader(
+        ChoiceLoaderInterface $loader,
+        ?callable $value = null,
+        ?callable $filter = null
+    ): ChoiceListInterface {
         return $this->executeWithRetry(function () use ($loader, $value, $filter) {
             return $this->choiceListFactory->createListFromLoader($loader, $value, $filter);
         });
     }
 
-    /** {@inheritDoc} */
+    /**
+     * @param array<string, mixed>|callable|null $preferredChoices
+     * @param array<string, mixed>|callable|null $attr
+     * @param array<string, mixed>|callable $labelTranslationParameters
+     *
+     * @throws \ErrorException
+     */
     public function createView(
         ChoiceListInterface $list,
-        $preferredChoices = null,
-        $label = null,
-        $index = null,
-        $groupBy = null,
-        $attr = null
+        array|callable|null $preferredChoices = null,
+        callable|false|null $label = null,
+        ?callable $index = null,
+        ?callable $groupBy = null,
+        array|callable|null $attr = null,
+        array|callable $labelTranslationParameters = []
+        /* , bool $duplicatePreferredChoices = true */
     ): ChoiceListView {
-        $labelTranslationParameters = \func_num_args() > 6 ? func_get_arg(6) : [];
-
-        return $this->executeWithRetry(function () use ($list, $preferredChoices, $label, $index, $groupBy, $attr, $labelTranslationParameters) {
-            return $this->choiceListFactory->createView(
-                $list,
-                $preferredChoices,
-                $label,
-                $index,
-                $groupBy,
-                $attr,
-                $labelTranslationParameters
-            );
-        });
+        return $this->executeWithRetry(
+            function () use ($list, $preferredChoices, $label, $index, $groupBy, $attr, $labelTranslationParameters) {
+                return $this->choiceListFactory->createView(
+                    $list,
+                    $preferredChoices,
+                    $label,
+                    $index,
+                    $groupBy,
+                    $attr,
+                    $labelTranslationParameters
+                );
+            }
+        );
     }
 
     /**
@@ -75,6 +91,8 @@ final class RetryChoiceListFactory implements ChoiceListFactoryInterface
      * @param callable(mixed ...$args): T $fn
      *
      * @return T
+     *
+     * @throws \ErrorException
      */
     private function executeWithRetry(callable $fn)
     {

--- a/src/lib/Core/Debug/Matcher/ObjectFunctionCallChainMatcher.php
+++ b/src/lib/Core/Debug/Matcher/ObjectFunctionCallChainMatcher.php
@@ -13,7 +13,16 @@ use Psy\TabCompletion\Matcher\ObjectMethodsMatcher;
 
 class ObjectFunctionCallChainMatcher extends ObjectMethodsMatcher
 {
-    public function getMatches(array $tokens, array $info = [])
+    /**
+     * @param array<mixed> $info
+     *
+     * @phpstan-param list<mixed> $tokens
+     *
+     * @return string[]
+     *
+     * @throws \ReflectionException
+     */
+    public function getMatches(array $tokens, array $info = []): array
     {
         $input = $this->getInput($tokens);
 
@@ -50,7 +59,6 @@ class ObjectFunctionCallChainMatcher extends ObjectMethodsMatcher
                 // start a new chain
                 $functionChainStarted = true;
                 $chain[] = $this->getObjectClass($group);
-                continue;
             }
         }
 
@@ -83,7 +91,10 @@ class ObjectFunctionCallChainMatcher extends ObjectMethodsMatcher
         ));
     }
 
-    protected function getTokenName($token)
+    /**
+     * @phpstan-param list<mixed> $token
+     */
+    protected function getTokenName(array|string $token): string
     {
         if (!is_array($token)) {
             return $token;
@@ -92,24 +103,36 @@ class ObjectFunctionCallChainMatcher extends ObjectMethodsMatcher
         return \token_name($token[0]);
     }
 
-    protected function isFunctionCall($tokenGroup): bool
+    /**
+     * @phpstan-param list<mixed> $tokenGroup
+     */
+    protected function isFunctionCall(array $tokenGroup): bool
     {
         return count($tokenGroup) >= 3 && self::tokenIs($tokenGroup[0], self::T_STRING)
                 && $tokenGroup[1] === '('
                 && end($tokenGroup) === ')';
     }
 
-    protected function getFunctionName($tokenGroup): string
+    /**
+     * @phpstan-param list<mixed> $tokenGroup
+     */
+    protected function getFunctionName(array $tokenGroup): string
     {
         return $tokenGroup[0][1];
     }
 
-    protected function isObjectCall($tokenGroup): bool
+    /**
+     * @phpstan-param list<mixed> $tokenGroup
+     */
+    protected function isObjectCall(array $tokenGroup): bool
     {
         return self::tokenIs(end($tokenGroup), self::T_VARIABLE);
     }
 
-    protected function getObjectClass($tokenGroup): string
+    /**
+     * @phpstan-param list<mixed> $tokenGroup
+     */
+    protected function getObjectClass(array $tokenGroup): string
     {
         $objectName = \str_replace('$', '', end($tokenGroup)[1]);
         $object = $this->getVariable($objectName);

--- a/src/lib/Core/Debug/Matcher/ThisObjectMethodsMatcher.php
+++ b/src/lib/Core/Debug/Matcher/ThisObjectMethodsMatcher.php
@@ -16,7 +16,14 @@ use ReflectionMethod;
 
 class ThisObjectMethodsMatcher extends ObjectMethodsMatcher
 {
-    public function getMatches(array $tokens, array $info = [])
+    /**
+     * @param array<mixed> $info
+     *
+     * @phpstan-param list<mixed> $tokens
+     *
+     * @return string[]
+     */
+    public function getMatches(array $tokens, array $info = []): array
     {
         $input = $this->getInput($tokens);
 

--- a/src/lib/Core/Debug/Shell/Shell.php
+++ b/src/lib/Core/Debug/Shell/Shell.php
@@ -17,10 +17,7 @@ use Psy\TabCompletion\Matcher\FunctionsMatcher;
 
 class Shell extends BaseShell
 {
-    /**
-     * @return array
-     */
-    protected function getDefaultMatchers()
+    protected function getDefaultMatchers(): array
     {
         $matchers = array_filter(parent::getDefaultMatchers(), static function (AbstractMatcher $matcher) {
             // Remove FunctionsMatcher as it spams autocomplete too much
@@ -36,7 +33,7 @@ class Shell extends BaseShell
     public function addBaseImports(): void
     {
         $level = 1;
-        while (strpos(dirname(__DIR__, $level), 'vendor') !== false) {
+        while (str_contains(dirname(__DIR__, $level), 'vendor')) {
             ++$level;
         }
         $dir = dirname(__DIR__, $level);
@@ -46,8 +43,8 @@ class Shell extends BaseShell
         );
 
         $baseImports = array_filter($classes, static function (string $classFcqn): bool {
-            return strpos($classFcqn, 'Ibexa\Behat\Browser\Element') === 0 ||
-                strpos($classFcqn, 'Ibexa\Behat\Browser\Locator') === 0;
+            return str_starts_with($classFcqn, 'Ibexa\Behat\Browser\Element') ||
+                str_starts_with($classFcqn, 'Ibexa\Behat\Browser\Locator');
         });
 
         foreach ($baseImports as $import) {
@@ -72,7 +69,7 @@ class Shell extends BaseShell
         $this->addInput(sprintf('sprintf("%s");', $message), true);
     }
 
-    public function displayExceptionMessage(Exception $e)
+    public function displayExceptionMessage(Exception $e): void
     {
         $this->writeMessage('The error message is: ' . $e->getMessage());
     }

--- a/tests/bundle/Form/RetryChoiceListFactoryTest.php
+++ b/tests/bundle/Form/RetryChoiceListFactoryTest.php
@@ -60,7 +60,7 @@ final class RetryChoiceListFactoryTest extends TestCase
     {
         $retryChoiceListFactory = new RetryChoiceListFactory(new UnstableChoiceListFactory(4));
         $this->expectException(ErrorException::class);
-        $retryChoiceListFactory->createListFromChoices([], null);
+        $retryChoiceListFactory->createListFromChoices([]);
     }
 
     public function testCreateListFromLoaderFail(): void

--- a/tests/bundle/Form/Stub/UnstableChoiceListFactory.php
+++ b/tests/bundle/Form/Stub/UnstableChoiceListFactory.php
@@ -30,7 +30,12 @@ final class UnstableChoiceListFactory implements ChoiceListFactoryInterface
         $this->successfulCallAfterNthTry = $successfulCallAfterNthTry;
     }
 
-    public function createListFromChoices(iterable $choices, callable $value = null)
+    /**
+     * @param iterable<string, mixed> $choices
+     *
+     * @throws \ErrorException
+     */
+    public function createListFromChoices(iterable $choices, callable $value = null, ?callable $filter = null): ChoiceListInterface
     {
         ++$this->createListFromChoicesCounter;
         $this->failIfNeeded($this->createListFromChoicesCounter);
@@ -38,22 +43,45 @@ final class UnstableChoiceListFactory implements ChoiceListFactoryInterface
         return new ArrayChoiceList([]);
     }
 
-    public function createListFromLoader(ChoiceLoaderInterface $loader, callable $value = null)
-    {
+    /**
+     * @throws \ErrorException
+     */
+    public function createListFromLoader(
+        ChoiceLoaderInterface $loader,
+        callable $value = null,
+        ?callable $filter = null
+    ): ChoiceListInterface {
         ++$this->createListFromLoaderCounter;
         $this->failIfNeeded($this->createListFromLoaderCounter);
 
         return new ArrayChoiceList([]);
     }
 
-    public function createView(ChoiceListInterface $list, $preferredChoices = null, $label = null, callable $index = null, callable $groupBy = null, $attr = null)
-    {
+    /**
+     * @param array<string, mixed>|callable|null $preferredChoices
+     * @param array<string, mixed>|callable|null $attr
+     * @param array<string, mixed>|callable $labelTranslationParameters
+     *
+     * @throws \ErrorException
+     */
+    public function createView(
+        ChoiceListInterface $list,
+        array|callable|null $preferredChoices = null,
+        callable|false|null $label = null,
+        ?callable $index = null,
+        ?callable $groupBy = null,
+        array|callable|null $attr = null,
+        array|callable $labelTranslationParameters = []/* , bool $duplicatePreferredChoices = true */
+    ): ChoiceListView {
         ++$this->createViewCounter;
         $this->failIfNeeded($this->createViewCounter);
 
         return new ChoiceListView([]);
     }
 
+    /**
+     * @throws \ErrorException
+     */
     private function failIfNeeded(int $callNumber): void
     {
         if ($callNumber <= $this->successfulCallAfterNthTry) {


### PR DESCRIPTION
> [!CAUTION]
> This is a part of bigger set of changes, to be merged together when ready
> - [x] :exclamation:  **Remove TMP commits before merge** :exclamation:

| :ticket: Issue | IBX-8470 |
|----------------|-----------|

> [!WARNING]
> This is not ready, we need to resolve `bex/behat-screenshot` upgrade to SF 6

#### Related PRs:
- https://github.com/ibexa/core/pull/447
- https://github.com/ibexa/doctrine-schema/pull/27

#### Description:

This PR bumps Symfony to v6 with necessary codebase upgrades.

Key changes:

- [x] [Composer] Forced PHP >= 8.3
- [x] [Git] Added missing src/contracts directory
- [x] Bumped Symfony packages requirements to ^6.4
- [x] [Composer] Bumped psy/psysh to ^0.12.4 which supports Symfony 6
- [x] [Composer] Dropped dependency on ci-scripts standalone app
- [x] [Composer] Dropped abandoned behat/mink-goutte-driver
- [x] [Composer] Dropped direct dependency on PHP CS Fixer
- [x] Aligned RetryChoiceListFactory with Symfony 6
- [x] [Tests] Aligned form tests with Symfony 6
- [x] [Tests] Aligned codebase with upgraded version of psy/psysh
- [x] [PHPStan] Removed resolved issues

#### QA:

Up to QA to decide.

#### Documentation:

No documentation required.