### PR TITLE
[4.6] Fixed issues found by PHPStan

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -231,6 +231,11 @@ parameters:
 			path: src/bundle/Initializer/BehatSiteAccessInitializer.php
 
 		-
+			message: "#^Call to an undefined method Behat\\\\Gherkin\\\\Node\\\\ScenarioLikeInterface\\:\\:hasTag\\(\\)\\.$#"
+			count: 1
+			path: src/bundle/Subscriber/StartScenarioSubscriber.php
+
+		-
 			message: "#^Cannot call method isStarted\\(\\) on object\\|null\\.$#"
 			count: 1
 			path: src/bundle/Subscriber/StartScenarioSubscriber.php
@@ -2366,16 +2371,6 @@ parameters:
 			path: src/lib/Core/Log/Failure/AnalysisResult.php
 
 		-
-			message: "#^Cannot call method getMessage\\(\\) on Exception\\|null\\.$#"
-			count: 1
-			path: src/lib/Core/Log/Failure/TestFailureData.php
-
-		-
-			message: "#^Cannot call method getTraceAsString\\(\\) on Exception\\|null\\.$#"
-			count: 1
-			path: src/lib/Core/Log/Failure/TestFailureData.php
-
-		-
 			message: "#^Method Ibexa\\\\Behat\\\\Core\\\\Log\\\\Failure\\\\TestFailureData\\:\\:__construct\\(\\) has parameter \\$applicationLogs with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/Core/Log/Failure/TestFailureData.php
@@ -2397,16 +2392,6 @@ parameters:
 
 		-
 			message: "#^Method Ibexa\\\\Behat\\\\Core\\\\Log\\\\Failure\\\\TestFailureData\\:\\:browserLogsContainFragment\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Core/Log/Failure/TestFailureData.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Core\\\\Log\\\\Failure\\\\TestFailureData\\:\\:exceptionMessageContainsFragment\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Core/Log/Failure/TestFailureData.php
-
-		-
-			message: "#^Method Ibexa\\\\Behat\\\\Core\\\\Log\\\\Failure\\\\TestFailureData\\:\\:exceptionStackTraceContainsFragment\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/lib/Core/Log/Failure/TestFailureData.php
 

--- a/src/lib/Core/Log/Failure/TestFailureData.php
+++ b/src/lib/Core/Log/Failure/TestFailureData.php
@@ -60,16 +60,18 @@ class TestFailureData
         return false;
     }
 
-    public function exceptionStackTraceContainsFragment(string $stackTraceFragment)
+    public function exceptionStackTraceContainsFragment(string $stackTraceFragment): bool
     {
-        return strpos($this->getFailedStepsResult()->getException()->getTraceAsString(), $stackTraceFragment) !== false;
+        $throwable = $this->getFailedStepsResult()->getException();
+
+        return $throwable !== null && strpos($throwable->getTraceAsString(), $stackTraceFragment) !== false;
     }
 
-    public function exceptionMessageContainsFragment(string $exceptionMessageFragment)
+    public function exceptionMessageContainsFragment(string $exceptionMessageFragment): bool
     {
-        $exceptionMessage = $this->getFailedStepsResult()->getException()->getMessage();
+        $throwable = $this->getFailedStepsResult()->getException();
 
-        return strpos($exceptionMessage, $exceptionMessageFragment) !== false;
+        return $throwable !== null && strpos($throwable->getMessage(), $exceptionMessageFragment) !== false;
     }
 
     public function browserLogsContainFragment(string $logFragment)


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----|


#### Description:

Seems there were some changes either to PHPStan or 3rd party Behat packages that started to cause CI to fail (within 3 months since the last successful run).

##### Issue 1: StartScenarioSubscriber

`\Behat\Behat\EventDispatcher\Event\BeforeScenarioTested::getScenario` returns an instance of `\Behat\Gherkin\Node\ScenarioLikeInterface` while `hasTag` that we try to call is defined on `\Behat\Gherkin\Node\TaggedNodeInterface`

If the subscriber is indeed executed and doesn't cause a fatal error, then it's just 3rd party bug related to type-hinting.

It's also possible that maybe we should retrieve the information we want using different API, but in that case Behat API would seem rather counter-intuitive IMO. It would require more investigation.

Added to baseline.

##### Issue 2: TestFailureData

`\Ibexa\Behat\Core\Log\Failure\TestFailureData` `exceptionStackTraceContainsFragment` and `exceptionMessageContainsFragment` methods code, at least theoretically, can encounter null reference exception. I provided a simple refactoring ensuring it doesn't happen. Not sure why PHPStan pointed this out only recently.

Aligned baseline.