### PR TITLE
IBX-9968: Resolved Symfony 7.x deprecations

### DIFF
--- a/src/bundle/DependencyInjection/IbexaBehatExtension.php
+++ b/src/bundle/DependencyInjection/IbexaBehatExtension.php
@@ -17,9 +17,9 @@ use Ibexa\Behat\Core\Log\Failure\KnownIssues\KnownIssueInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class IbexaBehatExtension extends Extension implements PrependExtensionInterface, CompilerPassInterface
 {


### PR DESCRIPTION
| :ticket: Issue | IBX-9968  |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Enabled Rector Symfony 7.0, 7.1 and 7.2 sets. Resolved the following deprecations:

```
* [symfony/http-kernel] Replaced usage of internal Symfony\Component\HttpKernel\DependencyInjection\Extension class
```

#### For QA:

Sanities.

#### Documentation:
N/A

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
