### PR TITLE
IBX-10228: Bump symfony/* requirement to ^7.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,20 +23,20 @@
         "liuggio/fastest": "^1.11",
         "php-http/client-common": "^2.1",
         "phpunit/phpunit": "^8.5 || ^9.0 || ^10.0",
-        "symfony/config": "^7.2",
-        "symfony/console": "^7.2",
-        "symfony/dependency-injection": "^7.2",
-        "symfony/lock": "^7.2",
-        "symfony/stopwatch": "^7.2",
-        "symfony/http-client": "^7.2",
-        "symfony/http-kernel": "^7.2",
-        "symfony/process": "^7.2",
-        "symfony/property-access": "^7.2",
-        "symfony/yaml": "^7.2",
+        "symfony/config": "^7.3",
+        "symfony/console": "^7.3",
+        "symfony/dependency-injection": "^7.3",
+        "symfony/lock": "^7.3",
+        "symfony/stopwatch": "^7.3",
+        "symfony/http-client": "^7.3",
+        "symfony/http-kernel": "^7.3",
+        "symfony/process": "^7.3",
+        "symfony/property-access": "^7.3",
+        "symfony/yaml": "^7.3",
         "psy/psysh": "^0.12.4",
         "oleg-andreyev/mink-phpwebdriver": "<1.3.3",
         "oleg-andreyev/mink-phpwebdriver-extension": "^1.0",
-        "symfony/form": "^7.2"
+        "symfony/form": "^7.3"
     },
     "require-dev": {
         "ibexa/code-style": "~2.0.0",
@@ -46,7 +46,7 @@
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-symfony": "^2.0",
-        "symfony/phpunit-bridge": "^7.2"
+        "symfony/phpunit-bridge": "^7.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
| :ticket: Issue | IBX-10228    |
|----------------|--------------|

#### Description:
This PR updates all symfony/* dependencies to ^7.3.

#### For QA:
N/A

#### Documentation:
N/A

