### PR TITLE
IBX-10534: Prevent early database connection initialization

### DIFF
--- a/features/setup/multirepository/multirepository.feature
+++ b/features/setup/multirepository/multirepository.feature
@@ -9,8 +9,10 @@ Feature: Multirepository setup for testing
             default:
                 url: 'mysql://INVALID:INVALID@127.0.0.1/INVALID'
                 server_version: '8.0'
+                use_savepoints: true
             second_connection:
                 url: '%env(resolve:DATABASE_URL)%'
+                use_savepoints: true
     """
       Given I copy the configuration from "ibexa.repositories.default" to "ibexa.repositories.new_repository"
       And I append configuration to "ibexa.repositories.new_repository.storage"
@@ -21,6 +23,9 @@ Feature: Multirepository setup for testing
         """
                 connection: second_connection
         """
+    And I set configuration to "default" siteaccess
+      | key                          | value          |
+      | repository                   | new_repository |
     And I set configuration to "admin_group" siteaccess
       | key                          | value          |
       | repository                   | new_repository |

--- a/features/setup/multirepository/multirepository.feature
+++ b/features/setup/multirepository/multirepository.feature
@@ -8,6 +8,7 @@ Feature: Multirepository setup for testing
         connections:
             default:
                 url: 'mysql://INVALID:INVALID@127.0.0.1/INVALID'
+                server_version: '8.0'
             second_connection:
                 url: '%env(resolve:DATABASE_URL)%'
     """


### PR DESCRIPTION
| :ticket: Issue | [IBX-10534](https://issues.ibexa.co/browse/IBX-10534) |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
I have reproduced this issue locally and found the piece of configuration responsible for causing early initialization of database connection.

I am using a following configuration for Doctrine DBAL:
```yaml
# config/packages/doctrine.yaml
doctrine: 
    dbal: 
        default_connection: default
        connections: 
            default: 
                url: 'mysql://INVALID:INVALID@127.0.0.1/INVALID'

                # IMPORTANT: You MUST configure your server version,
                # either here or in the DATABASE_URL env var (see .env file)
                #server_version: '16'
                use_savepoints: true
            second_connection: 
                url: '%env(resolve:DATABASE_URL)%'

                # IMPORTANT: You MUST configure your server version,
                # either here or in the DATABASE_URL env var (see .env file)
                #server_version: '16'
                use_savepoints: true
```
Note, that use_savepoints: true is added by Symfony recipe. This is the source of the issue, because as part of configuring itself, Doctrine will call Doctrine\DBAL\Connection::setNestTransactionsWithSavepoints method, which has the following body:
```php
// DoctrineDBALConnection::setNestTransactionsWithSavepoints
    public function setNestTransactionsWithSavepoints($nestTransactionsWithSavepoints)
    {
        if ($this->transactionNestingLevel > 0) {
            throw ConnectionException::mayNotAlterNestedTransactionWithSavepointsInTransaction();
        }

        if (! $this->getDatabasePlatform()->supportsSavepoints()) {
            throw ConnectionException::savepointsNotSupported();
        }

        $this->nestTransactionsWithSavepoints = (bool) $nestTransactionsWithSavepoints;
    }
```
`$this->getDatabasePlatform()` call normally would not initialize the connection, however we omit server_version in the configuration of the database connection (which Symfony recommends setting explicitly). Therefore, Doctrine is unable to determine what version of platform we are using, and falls back to asking database directly. This initializes the connection.

As part of the shutdown process, Symfony Kernel will close all connections that were initialized explicitly.

```php
// DoctrineBundleDoctrineBundleDoctrineBundle::shutdown
    public function shutdown()
    {
        if ($this->autoloader !== null) {
            spl_autoload_unregister($this->autoloader);
            $this->autoloader = null;
        }

        // Clear all entity managers to clear references to entities for GC
        if ($this->container->hasParameter('doctrine.entity_managers')) {
            foreach ($this->container->getParameter('doctrine.entity_managers') as $id) {
                if (! $this->container->initialized($id)) {
                    continue;
                }

                $this->container->get($id)->clear();
            }
        }
```
In case of the command being tested (visible in attached trace.out file), the issue is similar - it just does not happen during shutdown procedure, but instead happens because Connection is being initialized. Due to configuration (or lack thereof) database platform needs to be determined, which results in the error.

Due to the above, tests should in my opinion declare server_version explicitly to prevent early Connection initialization.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
