### PR TITLE
IBX-11173: Added Site Factory to Ibexa Experience regressions

### DIFF
--- a/behat_ibexa_experience.yaml
+++ b/behat_ibexa_experience.yaml
@@ -28,6 +28,7 @@ regression:
                 - '%paths.base%/vendor/ibexa/dashboard/features/setup/setup.feature'
                 - '%paths.base%/vendor/ibexa/connector-openai/features/setup/setup.feature'
                 - '%paths.base%/vendor/ibexa/activity-log/features/setup/setup.feature'
+                - '%paths.base%/vendor/ibexa/site-factory/features/setup.feature'
             contexts:
                 - Ibexa\Behat\API\Context\ContentContext
                 - Ibexa\Behat\API\Context\ContentTypeContext
@@ -49,6 +50,7 @@ regression:
                 - Ibexa\Workflow\Behat\Context\WorkflowContext
                 - Ibexa\AdminUi\Behat\BrowserContext\UserNotificationContext
                 - Ibexa\AdminUi\Behat\BrowserContext\ContentViewContext
+                - Ibexa\SiteFactory\Behat\Context\SiteFactoryContext
     
         experience:
             paths:
@@ -70,6 +72,7 @@ regression:
               - '%paths.base%/vendor/ibexa/connector-openai/features/browser'
               - '%paths.base%/vendor/ibexa/activity-log/features/browser'
               - '%paths.base%/vendor/ibexa/integrated-help/features/browser'
+              - '%paths.base%/vendor/ibexa/site-factory/features/SiteFactory.feature'
             filters:
                 tags: "~@broken&&@IbexaExperience"
             contexts: 
@@ -135,3 +138,5 @@ regression:
                 - Ibexa\ConnectorOpenAi\Behat\Context\AIAssistantContext
                 - Ibexa\ActivityLog\Behat\Context\ActivityLogContext
                 - Ibexa\IntegratedHelp\Behat\BrowserContext\IntegratedHelpContext
+                - Ibexa\SiteFactory\Behat\Context\SiteFactoryContext
+                - Ibexa\SiteFactory\Behat\Context\SiteFactoryFrontendContext


### PR DESCRIPTION
> [!CAUTION]
> - [ ] Target 4.6 once confirming failure and the fix on 5.0 

| :ticket: Issue | IBX-11173 |
|----------------|-----------|


#### Related PRs: 
- https://github.com/ibexa/site-factory/pull/159
- https://github.com/ibexa/site-factory/pull/139


#### Description:

Added Site Factory Behat tests to regressions.

Site Factory has stopped working properly since `v5.0.4`. The bug is on 5.0, so testing this now against 5.0, but aiming to merge this one into 4.6. 

##### TODO
- [x] Observe failure against 5.0 (https://github.com/ibexa/experience/actions/runs/25437652631/job/74619884492?pr=592#step:19:64)
```
  Scenario: Verify Sites                      # vendor/ibexa/site-factory/features/SiteFactory.feature:9
    Given There are 5 Sites with correct data # Ibexa\SiteFactory\Behat\Context\SiteFactoryFrontendContext::verifySites()
      Failed asserting that two strings are equal.
      --- Expected
      +++ Actual
      @@ @@
      -'Item: SkeletonPolski'
      +'Item: Ibexa Digital Experience Platform'
```
- [x] Observe success against ibexa/site-factory#159 (https://github.com/ibexa/experience/actions/runs/25487390002/job/74786421050?pr=592#step:19:39)

#### For QA:

Review.

5.0 regressions: https://github.com/ibexa/experience/pull/592

#### Documentation:
No Doc required.