### PR TITLE
IBX-11766: Removed prod phpunit dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
         "guzzlehttp/psr7": "^2.7",
         "liuggio/fastest": "^1.11",
         "php-http/client-common": "^2.1",
-        "phpunit/phpunit": "^8.5 || ^9.0 || ^10.0",
         "symfony/config": "^7.3",
         "symfony/console": "^7.3",
         "symfony/dependency-injection": "^7.3",
@@ -46,7 +45,8 @@
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-symfony": "^2.0",
-        "symfony/phpunit-bridge": "^7.3"
+        "symfony/phpunit-bridge": "^7.3",
+        "phpunit/phpunit": "^12.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
         "psy/psysh": "^0.12.4",
         "oleg-andreyev/mink-phpwebdriver": "<1.3.3",
         "oleg-andreyev/mink-phpwebdriver-extension": "^1.0",
-        "symfony/form": "^7.3"
+        "symfony/form": "^7.3",
+        "webmozart/assert": "^2.3"
     },
     "require-dev": {
         "ibexa/code-style": "~2.3.0",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -577,12 +577,6 @@ parameters:
 			path: src/lib/API/ContentData/FieldTypeData/SelectionDataProvider.php
 
 		-
-			message: '#^Parameter \#1 \$min \(1\) of function random_int expects lower number than parameter \#2 \$max \(int\<0, max\>\)\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/lib/API/ContentData/FieldTypeData/SelectionDataProvider.php
-
-		-
 			message: '#^Parameter \#1 \$selection of class Ibexa\\Core\\FieldType\\Selection\\Value constructor expects array\<int\>, list\<string\> given\.$#'
 			identifier: argument.type
 			count: 1
@@ -1083,12 +1077,6 @@ parameters:
 		-
 			message: '#^Method Ibexa\\Behat\\API\\Facade\\SearchFacade\:\:getRandomLocationID\(\) should return int but returns int\|null\.$#'
 			identifier: return.type
-			count: 1
-			path: src/lib/API/Facade/SearchFacade.php
-
-		-
-			message: '#^Parameter \#1 \$min \(0\) of function random_int expects lower number than parameter \#2 \$max \(int\<\-1, max\>\)\.$#'
-			identifier: argument.type
 			count: 1
 			path: src/lib/API/Facade/SearchFacade.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2947,12 +2947,6 @@ parameters:
 			path: tests/lib/Browser/Element/Criterion/ChildElementTextCriterionTest.php
 
 		-
-			message: '#^Call to an undefined method PHPUnit\\Framework\\MockObject\\Builder\\InvocationStubber\:\:with\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: tests/lib/Browser/Element/Criterion/ElementAttributeCriterionTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\Behat\\Browser\\Element\\Criterion\\ElementAttributeCriterionTest\:\:createElementWithAttribute\(\) has parameter \$attribute with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+<phpunit
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  backupGlobals="false"
+  bootstrap="vendor/autoload.php"
+  colors="true"
+  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd"
+  cacheDirectory=".phpunit.cache"
+  backupStaticProperties="false"
+>
   <coverage/>
   <testsuites>
     <testsuite name="Ibexa\Bundle\Behat">

--- a/src/lib/API/Facade/ContentFacade.php
+++ b/src/lib/API/Facade/ContentFacade.php
@@ -18,7 +18,7 @@ use Ibexa\Contracts\Core\Repository\URLAliasService;
 use Ibexa\Contracts\Core\Repository\Values\Content\Content;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 use Ibexa\Contracts\Core\Repository\Values\Content\URLAlias;
-use PHPUnit\Framework\Assert;
+use Webmozart\Assert\Assert;
 
 class ContentFacade
 {
@@ -63,7 +63,7 @@ class ContentFacade
         $contentItemData = null
     ): Content {
         $parentUrlAlias = $this->urlAliasService->lookup($parentUrl);
-        Assert::assertEquals(URLAlias::LOCATION, $parentUrlAlias->type);
+        Assert::eq($parentUrlAlias->type, URLAlias::LOCATION);
 
         $parentLocationId = $parentUrlAlias->destination;
         $locationCreateStruct = $this->locationService->newLocationCreateStruct((int) $parentLocationId);
@@ -111,7 +111,7 @@ class ContentFacade
         $contentItemData
     ): Content {
         $urlAlias = $this->urlAliasService->lookup($locationURL);
-        Assert::assertEquals(URLAlias::LOCATION, $urlAlias->type);
+        Assert::eq($urlAlias->type, URLAlias::LOCATION);
 
         $location = $this->locationService->loadLocation((int) $urlAlias->destination);
         $contentDraft = $this->contentService->createContentDraft($location->getContentInfo());
@@ -132,7 +132,7 @@ class ContentFacade
     public function getLocationByLocationURL($locationURL): Location
     {
         $urlAlias = $this->urlAliasService->lookup($locationURL);
-        Assert::assertEquals(URLAlias::LOCATION, $urlAlias->type);
+        Assert::eq($urlAlias->type, URLAlias::LOCATION);
 
         return $this->repository->sudo(function () use ($urlAlias) {
             return $this->locationService->loadLocation((int) $urlAlias->destination);

--- a/src/lib/API/Facade/SearchFacade.php
+++ b/src/lib/API/Facade/SearchFacade.php
@@ -19,7 +19,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\LogicalAnd;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\LogicalNot;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\Subtree;
 use Ibexa\Contracts\Core\Repository\Values\Content\URLAlias;
-use PHPUnit\Framework\Assert;
+use Webmozart\Assert\Assert;
 
 class SearchFacade
 {
@@ -54,7 +54,7 @@ class SearchFacade
     public function getRandomChildFromPath(string $path): string
     {
         $urlAlias = $this->urlAliasService->lookup($path);
-        Assert::assertEquals(URLAlias::LOCATION, $urlAlias->type);
+        Assert::eq($urlAlias->type, URLAlias::LOCATION);
 
         $location = $this->locationService->loadLocation((int) $urlAlias->destination);
 

--- a/src/lib/API/Facade/TrashFacade.php
+++ b/src/lib/API/Facade/TrashFacade.php
@@ -12,7 +12,7 @@ use Ibexa\Contracts\Core\Repository\LocationService;
 use Ibexa\Contracts\Core\Repository\TrashService;
 use Ibexa\Contracts\Core\Repository\URLAliasService;
 use Ibexa\Contracts\Core\Repository\Values\Content\URLAlias;
-use PHPUnit\Framework\Assert;
+use Webmozart\Assert\Assert;
 
 class TrashFacade
 {
@@ -38,7 +38,7 @@ class TrashFacade
     public function trash(string $locationURL)
     {
         $urlAlias = $this->urlAliasService->lookup($locationURL);
-        Assert::assertEquals(URLAlias::LOCATION, $urlAlias->type);
+        Assert::eq($urlAlias->type, URLAlias::LOCATION);
 
         $location = $this->locationService->loadLocation((int) $urlAlias->destination);
 

--- a/src/lib/Browser/Assert/CollectionAssert.php
+++ b/src/lib/Browser/Assert/CollectionAssert.php
@@ -11,7 +11,7 @@ namespace Ibexa\Behat\Browser\Assert;
 use Ibexa\Behat\Browser\Element\ElementCollectionInterface;
 use Ibexa\Behat\Browser\Element\Mapper\ElementTextMapper;
 use Ibexa\Behat\Browser\Locator\LocatorInterface;
-use PHPUnit\Framework\Assert;
+use Webmozart\Assert\Assert;
 
 class CollectionAssert implements CollectionAssertInterface
 {
@@ -35,7 +35,7 @@ class CollectionAssert implements CollectionAssertInterface
 
     public function isEmpty(): ElementCollectionInterface
     {
-        Assert::assertTrue(
+        Assert::true(
             $this->elementCollection->empty(),
             sprintf(
                 "Failed asserting that Collection created with %s locator '%s': '%s' is empty",
@@ -53,7 +53,7 @@ class CollectionAssert implements CollectionAssertInterface
         $elements = $this->elementCollection->toArray();
         $this->elementCollection->setElements($elements);
 
-        Assert::assertNotEmpty(
+        Assert::notEmpty(
             $elements,
             sprintf(
                 "Failed asserting that Collection created with %s locator '%s': '%s' is not empty",
@@ -71,9 +71,9 @@ class CollectionAssert implements CollectionAssertInterface
         $elements = $this->elementCollection->toArray();
         $this->elementCollection->setElements($elements);
 
-        Assert::assertCount(
-            $expectedCount,
+        Assert::count(
             $elements,
+            $expectedCount,
             sprintf(
                 "Failed asserting that Collection created with %s locator '%s': '%s' has %d elements. Found %s instead.",
                 $this->locator->getType(),
@@ -95,7 +95,7 @@ class CollectionAssert implements CollectionAssertInterface
         $elementTexts = $this->elementCollection->mapBy(new ElementTextMapper());
 
         foreach ($expectedElementTexts as $expectedElementText) {
-            Assert::assertContains(
+            Assert::inArray(
                 $expectedElementText,
                 $elementTexts,
                 sprintf(

--- a/src/lib/Browser/Assert/Debug/Interactive/CollectionAssert.php
+++ b/src/lib/Browser/Assert/Debug/Interactive/CollectionAssert.php
@@ -11,7 +11,7 @@ namespace Ibexa\Behat\Browser\Assert\Debug\Interactive;
 use Ibexa\Behat\Browser\Assert\CollectionAssertInterface;
 use Ibexa\Behat\Browser\Element\ElementCollectionInterface;
 use Ibexa\Behat\Core\Debug\InteractiveDebuggerTrait;
-use PHPUnit\Framework\ExpectationFailedException;
+use Webmozart\Assert\InvalidArgumentException;
 
 class CollectionAssert implements CollectionAssertInterface
 {
@@ -29,7 +29,7 @@ class CollectionAssert implements CollectionAssertInterface
     {
         try {
             return $this->baseCollectionAssert->isEmpty();
-        } catch (ExpectationFailedException $exception) {
+        } catch (InvalidArgumentException $exception) {
             return $this->startInteractiveSessionOnException($exception, true);
         }
     }
@@ -38,7 +38,7 @@ class CollectionAssert implements CollectionAssertInterface
     {
         try {
             return $this->baseCollectionAssert->hasElements();
-        } catch (ExpectationFailedException $exception) {
+        } catch (InvalidArgumentException $exception) {
             return $this->startInteractiveSessionOnException($exception, true);
         }
     }
@@ -47,7 +47,7 @@ class CollectionAssert implements CollectionAssertInterface
     {
         try {
             return $this->baseCollectionAssert->countEquals($expectedCount);
-        } catch (ExpectationFailedException $exception) {
+        } catch (InvalidArgumentException $exception) {
             return $this->startInteractiveSessionOnException($exception, true);
         }
     }
@@ -56,7 +56,7 @@ class CollectionAssert implements CollectionAssertInterface
     {
         try {
             return $this->baseCollectionAssert->containsElementsWithText($expectedElementTexts);
-        } catch (ExpectationFailedException $exception) {
+        } catch (InvalidArgumentException $exception) {
             return $this->startInteractiveSessionOnException($exception, true);
         }
     }

--- a/src/lib/Browser/Assert/Debug/Interactive/ElementAssert.php
+++ b/src/lib/Browser/Assert/Debug/Interactive/ElementAssert.php
@@ -11,7 +11,7 @@ namespace Ibexa\Behat\Browser\Assert\Debug\Interactive;
 use Ibexa\Behat\Browser\Assert\ElementAssertInterface;
 use Ibexa\Behat\Browser\Element\ElementInterface;
 use Ibexa\Behat\Core\Debug\InteractiveDebuggerTrait;
-use PHPUnit\Framework\ExpectationFailedException;
+use Webmozart\Assert\InvalidArgumentException;
 
 class ElementAssert implements ElementAssertInterface
 {
@@ -29,7 +29,7 @@ class ElementAssert implements ElementAssertInterface
     {
         try {
             return $this->baseElementAssert->textEquals($expectedText);
-        } catch (ExpectationFailedException $exception) {
+        } catch (InvalidArgumentException $exception) {
             return $this->startInteractiveSessionOnException($exception, true);
         }
     }
@@ -38,7 +38,7 @@ class ElementAssert implements ElementAssertInterface
     {
         try {
             return $this->baseElementAssert->textContains($expectedTextFragment);
-        } catch (ExpectationFailedException $exception) {
+        } catch (InvalidArgumentException $exception) {
             return $this->startInteractiveSessionOnException($exception, true);
         }
     }
@@ -47,7 +47,7 @@ class ElementAssert implements ElementAssertInterface
     {
         try {
             return $this->baseElementAssert->isVisible();
-        } catch (ExpectationFailedException $exception) {
+        } catch (InvalidArgumentException $exception) {
             return $this->startInteractiveSessionOnException($exception, true);
         }
     }
@@ -56,7 +56,7 @@ class ElementAssert implements ElementAssertInterface
     {
         try {
             return $this->baseElementAssert->hasClass($expectedClass);
-        } catch (ExpectationFailedException $exception) {
+        } catch (InvalidArgumentException $exception) {
             return $this->startInteractiveSessionOnException($exception, true);
         }
     }

--- a/src/lib/Browser/Assert/ElementAssert.php
+++ b/src/lib/Browser/Assert/ElementAssert.php
@@ -10,7 +10,7 @@ namespace Ibexa\Behat\Browser\Assert;
 
 use Ibexa\Behat\Browser\Element\ElementInterface;
 use Ibexa\Behat\Browser\Locator\LocatorInterface;
-use PHPUnit\Framework\Assert;
+use Webmozart\Assert\Assert;
 
 class ElementAssert implements ElementAssertInterface
 {
@@ -36,9 +36,9 @@ class ElementAssert implements ElementAssertInterface
     {
         $actualText = $this->element->getText();
 
-        Assert::assertEquals(
-            $expectedText,
+        Assert::eq(
             $actualText,
+            $expectedText,
             sprintf(
                 "Failed asserting that expected string '%s' is equal to actual '%s' for %s locator '%s': '%s'",
                 $expectedText,
@@ -56,9 +56,9 @@ class ElementAssert implements ElementAssertInterface
     {
         $actualText = $this->element->getText();
 
-        Assert::assertStringContainsString(
-            $expectedTextFragment,
+        Assert::contains(
             $actualText,
+            $expectedTextFragment,
             sprintf(
                 "Failed asserting that expected text '%s' is found in actual text '%s' for %s locator '%s': '%s'",
                 $expectedTextFragment,
@@ -74,7 +74,7 @@ class ElementAssert implements ElementAssertInterface
 
     public function isVisible(): ElementInterface
     {
-        Assert::assertTrue(
+        Assert::true(
             $this->element->isVisible(),
             sprintf(
                 "Failed asserting that %s locator '%s': '%s' is visible",
@@ -91,7 +91,7 @@ class ElementAssert implements ElementAssertInterface
     {
         $actualClass = $this->element->getAttribute('class');
 
-        Assert::assertTrue(
+        Assert::true(
             $this->element->hasClass($expectedClass),
             sprintf(
                 "Failed asserting that element with %s locator '%s': '%s' has '%s' class, instead class is '%s'",

--- a/src/lib/Browser/Context/BrowserContext.php
+++ b/src/lib/Browser/Context/BrowserContext.php
@@ -12,7 +12,7 @@ use Behat\Gherkin\Node\TableNode;
 use Behat\MinkExtension\Context\RawMinkContext;
 use DMore\ChromeDriver\ChromeDriver;
 use Ibexa\Behat\Core\Behat\ArgumentParser;
-use PHPUnit\Framework\Assert;
+use Webmozart\Assert\Assert;
 
 class BrowserContext extends RawMinkContext
 {
@@ -44,7 +44,7 @@ class BrowserContext extends RawMinkContext
         $responseHeaders = $this->getSession()->getDriver()->getResponseHeaders();
 
         foreach ($expectedHeadersData->getHash() as $row) {
-            Assert::assertEquals($row['Value'], $this->getHeaderValue($responseHeaders, $row['Header']));
+            Assert::eq($this->getHeaderValue($responseHeaders, $row['Header']), $row['Value']);
         }
     }
 
@@ -58,7 +58,7 @@ class BrowserContext extends RawMinkContext
         foreach ($expectedHeadersData->getHash() as $row) {
             $expectedValuePattern = $row['Pattern'];
             $actualValue = $this->getHeaderValue($responseHeaders, $row['Header']);
-            Assert::assertEquals(1, preg_match($expectedValuePattern, $actualValue));
+            Assert::eq(preg_match($expectedValuePattern, $actualValue), 1);
         }
     }
 

--- a/src/lib/Browser/Element/Debug/Interactive/ElementCollection.php
+++ b/src/lib/Browser/Element/Debug/Interactive/ElementCollection.php
@@ -16,8 +16,8 @@ use Ibexa\Behat\Browser\Element\ElementInterface;
 use Ibexa\Behat\Browser\Element\Mapper\MapperInterface;
 use Ibexa\Behat\Browser\Exception\ElementNotFoundException;
 use Ibexa\Behat\Core\Debug\InteractiveDebuggerTrait;
-use PHPUnit\Framework\ExpectationFailedException;
 use Traversable;
+use Webmozart\Assert\InvalidArgumentException;
 
 class ElementCollection implements ElementCollectionInterface
 {
@@ -95,7 +95,7 @@ class ElementCollection implements ElementCollectionInterface
     {
         try {
             return $this->baseElementCollection->single();
-        } catch (ExpectationFailedException $exception) {
+        } catch (InvalidArgumentException $exception) {
             return $this->startInteractiveSessionOnException($exception, true);
         }
     }

--- a/src/lib/Browser/Element/ElementCollection.php
+++ b/src/lib/Browser/Element/ElementCollection.php
@@ -14,8 +14,8 @@ use Ibexa\Behat\Browser\Element\Criterion\CriterionInterface;
 use Ibexa\Behat\Browser\Element\Mapper\MapperInterface;
 use Ibexa\Behat\Browser\Exception\ElementNotFoundException;
 use Ibexa\Behat\Browser\Locator\LocatorInterface;
-use PHPUnit\Framework\Assert;
 use Traversable;
+use Webmozart\Assert\Assert;
 
 class ElementCollection implements ElementCollectionInterface
 {
@@ -146,9 +146,9 @@ class ElementCollection implements ElementCollectionInterface
         if (!is_array($this->elements)) {
             $this->elements = iterator_to_array($this->elements);
         }
-        Assert::assertCount(
-            1,
+        Assert::count(
             $this->elements,
+            1,
             sprintf(
                 "Failed asserting that collection created with %s locator '%s': '%s' has only one element",
                 $this->locator->getType(),

--- a/src/lib/Browser/Page/LoginPage.php
+++ b/src/lib/Browser/Page/LoginPage.php
@@ -11,7 +11,7 @@ namespace Ibexa\Behat\Browser\Page;
 use Ibexa\Behat\Browser\Element\Criterion\ElementTextCriterion;
 use Ibexa\Behat\Browser\Element\Criterion\LogicalOrCriterion;
 use Ibexa\Behat\Browser\Locator\CSSLocator;
-use PHPUnit\Framework\Assert;
+use Webmozart\Assert\Assert;
 
 class LoginPage extends Page
 {
@@ -37,12 +37,12 @@ class LoginPage extends Page
             ->single()
             ->click();
 
-        Assert::assertNotEquals('/login', $this->getSession()->getCurrentUrl());
+        Assert::notEq($this->getSession()->getCurrentUrl(), '/login');
     }
 
     public function verifyIsLoaded(): void
     {
-        Assert::assertStringContainsString($this->getRoute(), $this->getSession()->getCurrentUrl());
+        Assert::contains($this->getSession()->getCurrentUrl(), $this->getRoute());
     }
 
     public function getName(): string

--- a/src/lib/Browser/Page/RedirectLoginPage.php
+++ b/src/lib/Browser/Page/RedirectLoginPage.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Behat\Browser\Page;
 
-use PHPUnit\Framework\Assert;
+use Webmozart\Assert\Assert;
 
 class RedirectLoginPage extends LoginPage
 {
@@ -19,7 +19,7 @@ class RedirectLoginPage extends LoginPage
 
     public function verifyIsLoaded(): void
     {
-        Assert::assertStringContainsString('/login', $this->getSession()->getCurrentUrl());
+        Assert::contains($this->getSession()->getCurrentUrl(), '/login');
     }
 
     public function loginSuccessfully(

--- a/src/lib/Core/Context/TimeContext.php
+++ b/src/lib/Core/Context/TimeContext.php
@@ -9,8 +9,8 @@ declare(strict_types=1);
 namespace Ibexa\Behat\Core\Context;
 
 use Behat\Behat\Context\Context;
-use PHPUnit\Framework\Assert;
 use Symfony\Component\Stopwatch\Stopwatch;
+use Webmozart\Assert\Assert;
 
 class TimeContext implements Context
 {
@@ -47,7 +47,7 @@ class TimeContext implements Context
         $actualDuration = $this->stopwatch->getEvent('event')->getDuration() / 1000;
         $this->stopwatch->reset();
 
-        Assert::assertLessThanOrEqual($maxDuration, $actualDuration);
+        Assert::lessThanEq($actualDuration, $maxDuration);
     }
 
     /**
@@ -59,6 +59,6 @@ class TimeContext implements Context
         $actualDuration = $this->stopwatch->getEvent('event')->getDuration() / 1000;
         $this->stopwatch->reset();
 
-        Assert::assertGreaterThan($maxDuration, $actualDuration);
+        Assert::greaterThan($actualDuration, $maxDuration);
     }
 }

--- a/src/lib/Subscriber/AbstractProcessStage.php
+++ b/src/lib/Subscriber/AbstractProcessStage.php
@@ -13,12 +13,12 @@ use Ibexa\Behat\Event\TransitionEvent;
 use Ibexa\Contracts\Core\Repository\PermissionResolver;
 use Ibexa\Contracts\Core\Repository\UserService;
 use Ibexa\Contracts\Core\Repository\Values\User\User;
-use PHPUnit\Framework\Assert;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Webmozart\Assert\Assert;
 
 abstract class AbstractProcessStage
 {
@@ -70,7 +70,7 @@ abstract class AbstractProcessStage
         }
 
         if (!$chosenEvent) {
-            Assert::fail('No event was chosen, possible error in transition logic.');
+            throw new \InvalidArgumentException('No event was chosen, possible error in transition logic.');
         }
 
         $this->eventDispatcher->dispatch($event, $chosenEvent);
@@ -96,7 +96,7 @@ abstract class AbstractProcessStage
             $sum += $probability;
         }
 
-        Assert::assertEquals(1, $sum, 'Sum of all probabilities must be equal to 1.');
+        Assert::eq($sum, 1, 'Sum of all probabilities must be equal to 1.');
     }
 
     protected function getRandomValue(array $values): string

--- a/tests/Browser/Element/Assert/CollectionAssertTest.php
+++ b/tests/Browser/Element/Assert/CollectionAssertTest.php
@@ -12,6 +12,7 @@ use Ibexa\Behat\Browser\Assert\CollectionAssert;
 use Ibexa\Behat\Browser\Element\ElementCollection;
 use Ibexa\Behat\Browser\Locator\XPathLocator;
 use Ibexa\Tests\Behat\Browser\Element\BaseTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\ExpectationFailedException;
 
 class CollectionAssertTest extends BaseTestCase
@@ -24,9 +25,7 @@ class CollectionAssertTest extends BaseTestCase
         $this->locator = new XPathLocator('locator', '//');
     }
 
-    /**
-     * @dataProvider provideForTestAssertionPasses
-     */
+    #[DataProvider('provideForTestAssertionPasses')]
     public function testAssertionPasses(
         array $expectedElementTexts,
         array $actualElementTexts
@@ -38,9 +37,7 @@ class CollectionAssertTest extends BaseTestCase
         self::assertSame($collection, $returnedCollection);
     }
 
-    /**
-     * @dataProvider provideForTestAssertionFails
-     */
+    #[DataProvider('provideForTestAssertionFails')]
     public function testAssertionFails(
         array $expectedElementTexts,
         array $actualElementTexts

--- a/tests/Browser/Element/Assert/CollectionAssertTest.php
+++ b/tests/Browser/Element/Assert/CollectionAssertTest.php
@@ -13,7 +13,7 @@ use Ibexa\Behat\Browser\Element\ElementCollection;
 use Ibexa\Behat\Browser\Locator\XPathLocator;
 use Ibexa\Tests\Behat\Browser\Element\BaseTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\ExpectationFailedException;
+use Webmozart\Assert\InvalidArgumentException;
 
 class CollectionAssertTest extends BaseTestCase
 {
@@ -42,7 +42,7 @@ class CollectionAssertTest extends BaseTestCase
         array $expectedElementTexts,
         array $actualElementTexts
     ): void {
-        $this->expectException(ExpectationFailedException::class);
+        $this->expectException(InvalidArgumentException::class);
         $collectionAssert = new CollectionAssert($this->locator, $this->createElementCollection($actualElementTexts));
         $collectionAssert->containsElementsWithText($expectedElementTexts);
     }

--- a/tests/Browser/Locator/Validator/CssLocatorValidatorTest.php
+++ b/tests/Browser/Locator/Validator/CssLocatorValidatorTest.php
@@ -10,6 +10,7 @@ namespace Ibexa\Tests\Behat\Browser\Locator\Validator;
 
 use Ibexa\Behat\Browser\Locator\CSSLocator;
 use Ibexa\Behat\Browser\Locator\Validator\CssLocatorValidator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\CssSelector\Exception\ParseException;
 
@@ -22,18 +23,14 @@ class CssLocatorValidatorTest extends TestCase
         $this->validator = new CssLocatorValidator();
     }
 
-    /**
-     * @dataProvider provideValidSelectors
-     */
+    #[DataProvider('provideValidSelectors')]
     public function testValidationPasses(string $selector): void
     {
         $this->validator->validate(new CSSLocator('test', $selector));
         $this->expectNotToPerformAssertions();
     }
 
-    /**
-     * @dataProvider provideInvalidSelectors
-     */
+    #[DataProvider('provideInvalidSelectors')]
     public function testValidationFails(string $selector): void
     {
         $this->expectException(ParseException::class);

--- a/tests/bundle/Form/RetryChoiceListFactoryTest.php
+++ b/tests/bundle/Form/RetryChoiceListFactoryTest.php
@@ -11,6 +11,7 @@ namespace Ibexa\Tests\Bundle\Behat\Form;
 use ErrorException;
 use Ibexa\Bundle\Behat\Form\RetryChoiceListFactory;
 use Ibexa\Tests\Bundle\Behat\Form\Stub\UnstableChoiceListFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\ClockMock;
 use Symfony\Component\Form\ChoiceList\ChoiceListInterface;
@@ -29,27 +30,21 @@ final class RetryChoiceListFactoryTest extends TestCase
         ClockMock::withClockMock(false);
     }
 
-    /**
-     * @dataProvider provider
-     */
+    #[DataProvider('provider')]
     public function testCreateListFromChoicesSuccess(int $numberOfFails): void
     {
         $retryChoiceListFactory = new RetryChoiceListFactory(new UnstableChoiceListFactory($numberOfFails));
         self::assertEquals([], $retryChoiceListFactory->createListFromChoices([], null)->getChoices());
     }
 
-    /**
-     * @dataProvider provider
-     */
+    #[DataProvider('provider')]
     public function testCreateListFromLoaderSuccess(int $numberOfFails): void
     {
         $retryChoiceListFactory = new RetryChoiceListFactory(new UnstableChoiceListFactory($numberOfFails));
         self::assertEquals([], $retryChoiceListFactory->createListFromLoader($this->createMock(ChoiceLoaderInterface::class))->getChoices());
     }
 
-    /**
-     * @dataProvider provider
-     */
+    #[DataProvider('provider')]
     public function testCreateViewSuccess(int $numberOfFails): void
     {
         $retryChoiceListFactory = new RetryChoiceListFactory(new UnstableChoiceListFactory($numberOfFails));

--- a/tests/lib/Browser/Element/Condition/ElementTransitionHasEndedConditionTest.php
+++ b/tests/lib/Browser/Element/Condition/ElementTransitionHasEndedConditionTest.php
@@ -68,12 +68,12 @@ class ElementTransitionHasEndedConditionTest extends BaseTestCase
     ): ElementInterface {
         $childElement = self::createStub(ElementInterface::class);
         $childElement->method('getText')->willReturn('ChildText');
-        $childElement->method('hasClass')->will(self::returnValueMap(
+        $childElement->method('hasClass')->willReturnMap(
             [
                 ['ibexa-selenium-transition-started', $hasStartedTransition],
                 ['ibexa-selenium-transition-ended', $hasEndedTransition],
             ]
-        ));
+        );
 
         return $childElement;
     }

--- a/tests/lib/Browser/Element/Criterion/ChildElementTextCriterionTest.php
+++ b/tests/lib/Browser/Element/Criterion/ChildElementTextCriterionTest.php
@@ -14,12 +14,11 @@ use Ibexa\Behat\Browser\Locator\LocatorInterface;
 use Ibexa\Behat\Browser\Locator\XPathLocator;
 use Ibexa\Tests\Behat\Browser\Element\BaseTestCase;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ChildElementTextCriterionTest extends BaseTestCase
 {
-    /**
-     * @dataProvider dataProviderTestMatches
-     */
+    #[DataProvider('dataProviderTestMatches')]
     public function testMatches(
         LocatorInterface $locator,
         string $childElementText,

--- a/tests/lib/Browser/Element/Criterion/ElementAttributeCriterionTest.php
+++ b/tests/lib/Browser/Element/Criterion/ElementAttributeCriterionTest.php
@@ -13,12 +13,11 @@ use Ibexa\Behat\Browser\Element\ElementInterface;
 use Ibexa\Behat\Browser\Locator\CSSLocator;
 use Ibexa\Tests\Behat\Browser\Element\BaseTestCase;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ElementAttributeCriterionTest extends BaseTestCase
 {
-    /**
-     * @dataProvider dataProviderTestMatches
-     */
+    #[DataProvider('dataProviderTestMatches')]
     public function testMatches(
         string $attributeName,
         string $attributeValue,

--- a/tests/lib/Browser/Element/Criterion/ElementTextCriterionTest.php
+++ b/tests/lib/Browser/Element/Criterion/ElementTextCriterionTest.php
@@ -12,12 +12,11 @@ use Ibexa\Behat\Browser\Element\Criterion\ElementTextCriterion;
 use Ibexa\Behat\Browser\Locator\CSSLocator;
 use Ibexa\Tests\Behat\Browser\Element\BaseTestCase;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ElementTextCriterionTest extends BaseTestCase
 {
-    /**
-     * @dataProvider dataProviderTestMatches
-     */
+    #[DataProvider('dataProviderTestMatches')]
     public function testMatches(
         string $elementText,
         bool $shouldMatch

--- a/tests/lib/Browser/Element/Criterion/ElementTextFragmentCriterionTest.php
+++ b/tests/lib/Browser/Element/Criterion/ElementTextFragmentCriterionTest.php
@@ -12,12 +12,11 @@ use Ibexa\Behat\Browser\Element\Criterion\ElementTextFragmentCriterion;
 use Ibexa\Behat\Browser\Locator\CSSLocator;
 use Ibexa\Tests\Behat\Browser\Element\BaseTestCase;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ElementTextFragmentCriterionTest extends BaseTestCase
 {
-    /**
-     * @dataProvider dataProviderTestMatches
-     */
+    #[DataProvider('dataProviderTestMatches')]
     public function testMatches(
         string $elementText,
         bool $shouldMatch

--- a/tests/lib/Browser/Element/ElementCollectionTest.php
+++ b/tests/lib/Browser/Element/ElementCollectionTest.php
@@ -16,6 +16,7 @@ use Ibexa\Behat\Browser\Exception\ElementNotFoundException;
 use Ibexa\Behat\Browser\Locator\CSSLocator;
 use Ibexa\Behat\Browser\Locator\LocatorInterface;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ElementCollectionTest extends BaseTestCase
 {
@@ -61,9 +62,7 @@ class ElementCollectionTest extends BaseTestCase
         Assert::assertEquals(3, $this->collection->count());
     }
 
-    /**
-     * @dataProvider dataProviderTestAny
-     */
+    #[DataProvider('dataProviderTestAny')]
     public function testAny(
         LocatorInterface $locator,
         array $elementNames,
@@ -89,9 +88,7 @@ class ElementCollectionTest extends BaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider dataProviderTestEmpty
-     */
+    #[DataProvider('dataProviderTestEmpty')]
     public function testEmpty(
         LocatorInterface $locator,
         array $elementNames,

--- a/tests/lib/Browser/Element/ElementTest.php
+++ b/tests/lib/Browser/Element/ElementTest.php
@@ -18,6 +18,7 @@ use Ibexa\Behat\Browser\Locator\CSSLocator;
 use Ibexa\Behat\Browser\Locator\LocatorInterface;
 use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ElementTest extends BaseTestCase
 {
@@ -132,9 +133,7 @@ class ElementTest extends BaseTestCase
         $element->waitUntilCondition(new ElementExistsCondition($searchedElement, $this->irrelevantLocator));
     }
 
-    /**
-     * @dataProvider dataProvidertestAdditionalLocatorConditionsAreAppliedWhenUsingFind
-     */
+    #[DataProvider('dataProvidertestAdditionalLocatorConditionsAreAppliedWhenUsingFind')]
     public function testAdditionalLocatorConditionsAreAppliedWhenUsingFind(
         LocatorInterface $locator,
         string $expectedElementText
@@ -158,9 +157,7 @@ class ElementTest extends BaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider dataProvidertestAdditionalLocatorConditionsAreAppliedWhenUsingFindAll
-     */
+    #[DataProvider('dataProvidertestAdditionalLocatorConditionsAreAppliedWhenUsingFindAll')]
     public function testAdditionalLocatorConditionsAreAppliedWhenUsingFindAll(
         LocatorInterface $locator,
         int $expectedElementCount

--- a/tests/lib/Core/Behat/ArgumentParserTest.php
+++ b/tests/lib/Core/Behat/ArgumentParserTest.php
@@ -12,6 +12,7 @@ use Ibexa\Behat\API\Facade\RoleFacade;
 use Ibexa\Behat\Browser\Environment\ParameterProvider;
 use Ibexa\Behat\Core\Behat\ArgumentParser;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -21,9 +22,7 @@ use PHPUnit\Framework\TestCase;
  */
 class ArgumentParserTest extends TestCase
 {
-    /**
-     * @dataProvider provideUrlData
-     */
+    #[DataProvider('provideUrlData')]
     public function testParserGivenUrlCorrectly(
         string $valueToParse,
         string $expectedResult


### PR DESCRIPTION
> [!CAUTION]
> - [x] Remove tmp commit before merging 

| :ticket: Issue | [IBX-11766](https://ibexa.atlassian.net/browse/IBX-11766) |
|----------------|-----------|

#### Related PRs: 
https://github.com/ibexa/behat/pull/183

#### Description:
The main goal is to unblock updating of phpunit/phpunit in ibexa/* dev dependencies to a version higher than 10. Currently, this package narrows it down to max version 10.

This PR moves phpunit from prod to dev dependencies (updated to version `^12.5`). In `src/` directory it replaces phpunit assertions with webmozart ones.

### Merging procedure
Unfortunately, because of high dependency cascade coupling between our packages which have some behat related logic in code - it's hard (or almost impossible) to make each separate package PR work standalone. Each of them needs to have mocked direct and indirect custom dependencies to all other packages (where we're replacing phpunit assertions with webmozart ones), because otherwise we have conflicts between webmozart versions (some packages have dependency to webmozart:v1 and I updated all packages to version ^2.3).

It's agreed that we'll merge this PR and all related (all mentioned in this PR) altogether. That should align all webmozart versions into one `^2.3`, so we don't expect to have composer dependencies conflicts. Afterwards, if they're ll be any failing CI jobs - I'll handle and fix them one by one.

#### For QA:
#### Documentation:

[IBX-11766]: https://ibexa.atlassian.net/browse/IBX-11766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ