### PR TITLE
Fixed rector configure() reports across Command classes

### DIFF
--- a/src/bundle/Command/CreateExampleDataCommand.php
+++ b/src/bundle/Command/CreateExampleDataCommand.php
@@ -53,7 +53,7 @@ class CreateExampleDataCommand extends Command
         $this->logger = $logger;
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->addArgument('iterations', InputArgument::REQUIRED)

--- a/src/bundle/Command/CreateLanguageCommand.php
+++ b/src/bundle/Command/CreateLanguageCommand.php
@@ -41,7 +41,7 @@ class CreateLanguageCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->addArgument('language-code', InputArgument::REQUIRED)

--- a/src/bundle/Command/TestSiteaccessCommand.php
+++ b/src/bundle/Command/TestSiteaccessCommand.php
@@ -27,8 +27,6 @@ class TestSiteaccessCommand extends Command
         parent::__construct();
     }
 
-    protected function configure() {}
-
     protected function execute(
         InputInterface $input,
         OutputInterface $output

--- a/src/lib/Core/Debug/Command/GoBackCommand.php
+++ b/src/lib/Core/Debug/Command/GoBackCommand.php
@@ -26,7 +26,7 @@ class GoBackCommand extends Command
         $this->session = $session;
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDefinition([])

--- a/src/lib/Core/Debug/Command/RefreshPageCommand.php
+++ b/src/lib/Core/Debug/Command/RefreshPageCommand.php
@@ -26,7 +26,7 @@ class RefreshPageCommand extends Command
         $this->session = $session;
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDefinition([])

--- a/src/lib/Core/Debug/Command/ShowHTMLCommand.php
+++ b/src/lib/Core/Debug/Command/ShowHTMLCommand.php
@@ -26,7 +26,7 @@ class ShowHTMLCommand extends Command
         $this->session = $session;
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDefinition([])

--- a/src/lib/Core/Debug/Command/ShowURLCommand.php
+++ b/src/lib/Core/Debug/Command/ShowURLCommand.php
@@ -26,7 +26,7 @@ class ShowURLCommand extends Command
         $this->session = $session;
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDefinition([])

--- a/src/lib/Core/Debug/Command/TakeScreenshotCommand.php
+++ b/src/lib/Core/Debug/Command/TakeScreenshotCommand.php
@@ -34,7 +34,7 @@ class TakeScreenshotCommand extends Command
         $this->session = $session;
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDefinition([])


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----------|

#### Related PRs:
- rectorphp/rector-symfony#966
- https://github.com/ibexa/scheduler/pull/174
- https://github.com/ibexa/personalization/pull/414

#### Description:

The `Run rector` job is red on `5.0` and `6.0`. It last ran green in May 2026 against an older `rector/rector`; several rules have tightened since. There are two independent causes, kept as two commits:

1. **Removed empty `configure()` from `TestSiteaccessCommand`.** `rector/rector` 2.5.8 (released 2026-07-27) extended `CommandConfigureToAttributeRector` to also delete the `configure()` method it leaves empty when a command's name is moved to the `#[AsCommand]` attribute — see rectorphp/rector-symfony#966. This is the same failure that hit ibexa/scheduler and ibexa/personalization.

2. **Added `: void` to the remaining seven `configure()` overrides.** `AddReturnTypeDeclarationRector` reports every `configure()` override that omits the return type. These were already flagged before 2.5.8 and are unrelated to the empty-method removal, but the job cannot go green while they remain. Symfony's `Command::configure()` declares no return type, so narrowing it to `void` in a subclass is allowed.

Both commits are rector's own output, applied with `vendor/bin/rector process`. Neither changes behaviour.

This targets `5.0` because both problems are present on `5.0` and `6.0` and `5.0` is the oldest affected branch. The regular `5.0` → `6.0` merge-up carries the fix forward.

#### For QA:

No functional change. Every affected command keeps its existing name, description and definition — only the dead method and missing return types change.

Verified locally on `5.0` with `rector/rector` 2.5.8 installed. Reproduced the failure first (exit 2, 8 files reported), then confirmed green after the change:

- `vendor/bin/rector process --dry-run` — exit 0, `[OK] Rector is done!`
- `composer check-cs` — exit 0
- `composer test` — exit 0 (170 tests, 178 assertions; the 4 PHPUnit deprecations and 58 notices are pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
