### PR TITLE
IBX-12204: Read current SiteAccess via SiteAccessServiceInterface

### DIFF
--- a/src/bundle/Command/TestSiteaccessCommand.php
+++ b/src/bundle/Command/TestSiteaccessCommand.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\Behat\Command;
 
-use Ibexa\Core\MVC\Symfony\SiteAccess;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -17,12 +17,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'ibexa:behat:test-siteaccess', description: 'Outputs the name of the active siteaccess')]
 class TestSiteaccessCommand extends Command
 {
-    /** @var SiteAccess */
-    private $siteaccess;
+    private SiteAccessServiceInterface $siteAccessService;
 
-    public function __construct(SiteAccess $siteaccess)
+    public function __construct(SiteAccessServiceInterface $siteAccessService)
     {
-        $this->siteaccess = $siteaccess;
+        $this->siteAccessService = $siteAccessService;
 
         parent::__construct();
     }
@@ -31,7 +30,8 @@ class TestSiteaccessCommand extends Command
         InputInterface $input,
         OutputInterface $output
     ): int {
-        $output->writeln($this->siteaccess->name);
+        $siteAccess = $this->siteAccessService->getCurrent();
+        $output->writeln($siteAccess !== null ? $siteAccess->name : '');
 
         return self::SUCCESS;
     }

--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -73,7 +73,7 @@ services:
 
     Ibexa\Bundle\Behat\Command\TestSiteaccessCommand:
         arguments:
-            $siteaccess: '@Ibexa\Core\MVC\Symfony\SiteAccess'
+            $siteAccessService: '@Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface'
         tags:
             - { name: console.command }
 


### PR DESCRIPTION
| :ticket: Issue | [IBX-12204](https://ibexa.atlassian.net/browse/IBX-12204) |
|----------------|-----------|

#### Related PRs:
- https://github.com/ibexa/core/pull/798

#### Description:

`ibexa/core`'s [#798](https://github.com/ibexa/core/pull/798) (IBX-12204) refactors `SiteAccessService` so it no longer relies on the legacy, shared, container-wide `Ibexa\Core\MVC\Symfony\SiteAccess` singleton service. As part of that, `Ibexa\Bundle\Core\EventListener\ConsoleCommandListener` stops mutating that shared singleton in place on every console command run — it now only calls `SiteAccessService::changeSiteAccess()` with a freshly-constructed `SiteAccess`.

`TestSiteaccessCommand` (`ibexa:behat:test-siteaccess`) type-hinted that shared singleton directly to print the CLI-resolved siteaccess name, so it broke: it now always prints the singleton's boot-time placeholder value instead of the real one. This is exercised by `ibexa/core`'s own `src/bundle/Core/Features/Console/console.feature` scenario "Commands use the default siteaccess if not specified" (currently tagged `@broken` on the core PR pending this fix).

Fix: inject `SiteAccessServiceInterface` instead and read the current SiteAccess via `getCurrent()`.

#### For QA:

Once this PR and ibexa/core#798 are both available, running `bin/console ibexa:behat:test-siteaccess` (with or without `--siteaccess=<name>`) should print the resolved siteaccess name, matching the two `console.feature` scenarios in `ibexa/core`.

#### Documentation:

None needed — internal Behat test fixture.


[IBX-12204]: https://ibexa.atlassian.net/browse/IBX-12204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ